### PR TITLE
Fix npm trusted publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,8 +1,8 @@
 name: Publish to NPM
 
-# Manual, on-demand publishing (mirrors the DxMessaging release route): dispatch this workflow
-# to publish the current package.json version. The publish step is re-runnable (it skips a
-# version already on the registry) and attaches build provenance.
+# Manual, on-demand publishing: dispatch this workflow to publish the current package.json
+# version. The publish step is re-runnable (it skips a version already on the registry) and
+# uses npm Trusted Publishing through GitHub OIDC.
 on:
   workflow_dispatch:
     inputs:
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
-      id-token: write # required for `npm publish --provenance`
+      id-token: write # required for npm Trusted Publishing through OIDC
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -35,8 +35,9 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
 
       - name: Pack and resolve version / dist-tag
         id: pack
@@ -63,10 +64,21 @@ jobs:
           } >> "${GITHUB_OUTPUT}"
           echo "Prepared ${pkg}@${ver} -> dist-tag '${npm_tag}' (${package_file})."
 
-      - name: Publish to npm with provenance
+      - name: Verify npm trusted publishing toolchain
+        run: |
+          set -euo pipefail
+          node --version
+          npm --version
+          required_npm="11.5.1"
+          current_npm="$(npm --version)"
+          if [ "$(printf '%s\n' "${required_npm}" "${current_npm}" | sort -V | head -n1)" != "${required_npm}" ]; then
+            echo "::error::npm ${current_npm} is too old; trusted publishing requires npm >= ${required_npm}."
+            exit 1
+          fi
+
+      - name: Publish to npm with trusted publishing
         if: ${{ inputs.dry_run == false }}
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           PKG: ${{ steps.pack.outputs.pkg }}
           VER: ${{ steps.pack.outputs.ver }}
           NPM_TAG: ${{ steps.pack.outputs.npm_tag }}
@@ -78,7 +90,7 @@ jobs:
           if npm view "${PKG}@${VER}" version >/dev/null 2>&1; then
             echo "::notice::${PKG}@${VER} is already on the registry; skipping publish."
           else
-            npm publish "${PACKAGE_FILE}" --provenance --access public --tag "${NPM_TAG}"
+            npm publish "${PACKAGE_FILE}" --access public --tag "${NPM_TAG}"
             echo "::notice::Published ${PKG}@${VER} to dist-tag '${NPM_TAG}'."
           fi
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,19 @@
   "author": "wallstop studios <wallstop@wallstopstudios.com> (https://wallstopstudios.com)",
   "homepage": "https://github.com/wallstop/DataVisualizer#readme",
   "main": "README.md",
+  "files": [
+    "Editor",
+    "Editor.meta",
+    "Runtime",
+    "Runtime.meta",
+    "Tests",
+    "Tests.meta",
+    "docs",
+    "docs.meta",
+    "README.md.meta",
+    "LICENSE.meta",
+    "package.json.meta"
+  ],
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   }


### PR DESCRIPTION
## Summary

- Switch the manual npm publish workflow from token/provenance publishing to npm Trusted Publishing through GitHub OIDC.
- Move the workflow to Node 24, disable release-build package-manager caching, and add a fail-fast npm CLI version gate for `>=11.5.1`.
- Add a `package.json.files` allowlist so the npm tarball contains only the Unity package surface and required root Unity `.meta` files.

## Root Cause

The publish job still exported `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` and used `npm publish --provenance`. The secret is no longer populated, so npm did not authenticate through Trusted Publishing and failed with `ENEEDAUTH`. Node 22 also risks bundling npm below the Trusted Publishing minimum.

## Validation

- `npm pack --dry-run --json`
- Local package allowlist assertion over the dry-run file list: 126 files, required Unity package files present, forbidden repo/local paths absent.
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/npm-publish.yml')"`
- `git diff --check`
- Two adversarial review passes; the first replaced a fragile `.npmignore` blocklist with the current `package.json.files` allowlist, the second found zero issues.

## Risk / Rollback

Risk is limited to the manual npm publish workflow and package tarball contents. Rollback is reverting this commit and restoring token-based publishing while npm Trusted Publisher settings are corrected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only affect the manual publish workflow and tarball contents; wrong OIDC/npm setup or a bad `files` list could block releases or omit required Unity assets.
> 
> **Overview**
> Fixes manual npm publishing that failed with **`ENEEDAUTH`** after **`NPM_TOKEN`** was removed: the workflow now relies on **npm Trusted Publishing** via GitHub **OIDC** (`id-token: write`), drops **`NODE_AUTH_TOKEN`** and **`--provenance`**, and documents that model in comments.
> 
> The publish job moves to **Node 24**, sets **`package-manager-cache: false`**, and adds a **fail-fast** check that **npm ≥ 11.5.1** (Trusted Publishing minimum) before publish.
> 
> **`package.json`** gains a **`files`** allowlist so **`npm pack`** ships only the Unity package layout (**Editor**, **Runtime**, **Tests**, **docs**, and required root **`.meta`** files) instead of unrelated repo content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b5db76e10a929808bf60fa1c07c6e418d11f77f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->