### PR TITLE
Fix settings persistence dirty state

### DIFF
--- a/Editor/DataVisualizer/Data/DataVisualizerSettings.cs
+++ b/Editor/DataVisualizer/Data/DataVisualizerSettings.cs
@@ -96,6 +96,18 @@ namespace WallstopStudios.DataVisualizer.Editor.Data
 #endif
         }
 
+        public bool SetSelectActiveObject(bool value)
+        {
+            if (selectActiveObject == value)
+            {
+                return false;
+            }
+
+            selectActiveObject = value;
+            MarkDirty();
+            return true;
+        }
+
         public void HydrateFrom(DataVisualizerUserState userState)
         {
             if (userState == null)
@@ -197,6 +209,38 @@ namespace WallstopStudios.DataVisualizer.Editor.Data
                 string.Equals(o.namespaceKey, namespaceKey, StringComparison.Ordinal)
             );
             return entry != null;
+        }
+
+        public bool SetNamespaceCollapsed(string namespaceKey, bool isCollapsed)
+        {
+            if (string.IsNullOrWhiteSpace(namespaceKey))
+            {
+                return false;
+            }
+
+            namespaceCollapseStates ??= new List<NamespaceCollapseState>();
+            bool changed = NamespaceCollapseState.SetCollapsed(
+                namespaceCollapseStates,
+                namespaceKey,
+                isCollapsed
+            );
+            if (changed)
+            {
+                MarkDirty();
+            }
+
+            return changed;
+        }
+
+        public bool RemoveNamespaceCollapseState(string namespaceKey)
+        {
+            bool changed = NamespaceCollapseState.Remove(namespaceCollapseStates, namespaceKey);
+            if (changed)
+            {
+                MarkDirty();
+            }
+
+            return changed;
         }
 
         internal NamespaceCollapseState GetOrCreateCollapseState(string namespaceKey)

--- a/Editor/DataVisualizer/Data/DataVisualizerSettings.cs
+++ b/Editor/DataVisualizer/Data/DataVisualizerSettings.cs
@@ -156,24 +156,54 @@ namespace WallstopStudios.DataVisualizer.Editor.Data
             return entry.ObjectGuids;
         }
 
-        internal void SetLastObjectForType(string typeName, string guid)
+        internal bool SetLastObjectForType(string typeName, string guid)
         {
             if (string.IsNullOrWhiteSpace(typeName))
             {
-                return;
+                return false;
             }
 
-            if (string.IsNullOrWhiteSpace(guid))
-            {
-                return;
-            }
-
-            lastObjectSelections.RemoveAll(e =>
+            lastObjectSelections ??= new List<LastObjectSelectionEntry>();
+            int existingIndex = lastObjectSelections.FindIndex(e =>
                 string.Equals(e.typeFullName, typeName, StringComparison.Ordinal)
             );
-            lastObjectSelections.Add(
-                new LastObjectSelectionEntry { typeFullName = typeName, objectGuid = guid }
-            );
+            if (string.IsNullOrWhiteSpace(guid))
+            {
+                if (existingIndex < 0)
+                {
+                    return false;
+                }
+
+                lastObjectSelections.RemoveAt(existingIndex);
+                MarkDirty();
+                return true;
+            }
+
+            if (
+                existingIndex >= 0
+                && string.Equals(
+                    lastObjectSelections[existingIndex].objectGuid,
+                    guid,
+                    StringComparison.Ordinal
+                )
+            )
+            {
+                return false;
+            }
+
+            if (existingIndex >= 0)
+            {
+                lastObjectSelections[existingIndex].objectGuid = guid;
+            }
+            else
+            {
+                lastObjectSelections.Add(
+                    new LastObjectSelectionEntry { typeFullName = typeName, objectGuid = guid }
+                );
+            }
+
+            MarkDirty();
+            return true;
         }
 
         internal string GetLastObjectForType(string typeName)
@@ -184,7 +214,7 @@ namespace WallstopStudios.DataVisualizer.Editor.Data
             }
 
             return lastObjectSelections
-                .Find(e => string.Equals(e.typeFullName, typeName, StringComparison.Ordinal))
+                ?.Find(e => string.Equals(e.typeFullName, typeName, StringComparison.Ordinal))
                 ?.objectGuid;
         }
 

--- a/Editor/DataVisualizer/Data/DataVisualizerSettings.cs
+++ b/Editor/DataVisualizer/Data/DataVisualizerSettings.cs
@@ -41,7 +41,8 @@ namespace WallstopStudios.DataVisualizer.Editor.Data
 
         [SerializeField]
         [ReadOnly]
-        internal string lastSelectedTypeName;
+        [FormerlySerializedAs("lastSelectedTypeName")]
+        internal string lastSelectedTypeFullName;
 
         [SerializeField]
         [ReadOnly]
@@ -116,7 +117,7 @@ namespace WallstopStudios.DataVisualizer.Editor.Data
             }
 
             lastSelectedNamespaceKey = userState.lastSelectedNamespaceKey;
-            lastSelectedTypeName = userState.lastSelectedTypeName;
+            lastSelectedTypeFullName = userState.lastSelectedTypeFullName;
             namespaceOrder = userState.namespaceOrder?.ToList() ?? new List<string>();
             typeOrders =
                 userState.typeOrders?.Select(order => order.Clone()).ToList()

--- a/Editor/DataVisualizer/Data/DataVisualizerSettings.cs
+++ b/Editor/DataVisualizer/Data/DataVisualizerSettings.cs
@@ -156,16 +156,16 @@ namespace WallstopStudios.DataVisualizer.Editor.Data
             return entry.ObjectGuids;
         }
 
-        internal bool SetLastObjectForType(string typeName, string guid)
+        internal bool SetLastObjectForType(string typeFullName, string guid)
         {
-            if (string.IsNullOrWhiteSpace(typeName))
+            if (string.IsNullOrWhiteSpace(typeFullName))
             {
                 return false;
             }
 
             lastObjectSelections ??= new List<LastObjectSelectionEntry>();
             int existingIndex = lastObjectSelections.FindIndex(e =>
-                string.Equals(e.typeFullName, typeName, StringComparison.Ordinal)
+                string.Equals(e.typeFullName, typeFullName, StringComparison.Ordinal)
             );
             if (string.IsNullOrWhiteSpace(guid))
             {
@@ -198,7 +198,7 @@ namespace WallstopStudios.DataVisualizer.Editor.Data
             else
             {
                 lastObjectSelections.Add(
-                    new LastObjectSelectionEntry { typeFullName = typeName, objectGuid = guid }
+                    new LastObjectSelectionEntry { typeFullName = typeFullName, objectGuid = guid }
                 );
             }
 
@@ -206,15 +206,15 @@ namespace WallstopStudios.DataVisualizer.Editor.Data
             return true;
         }
 
-        internal string GetLastObjectForType(string typeName)
+        internal string GetLastObjectForType(string typeFullName)
         {
-            if (string.IsNullOrWhiteSpace(typeName))
+            if (string.IsNullOrWhiteSpace(typeFullName))
             {
                 return null;
             }
 
             return lastObjectSelections
-                ?.Find(e => string.Equals(e.typeFullName, typeName, StringComparison.Ordinal))
+                ?.Find(e => string.Equals(e.typeFullName, typeFullName, StringComparison.Ordinal))
                 ?.objectGuid;
         }
 

--- a/Editor/DataVisualizer/Data/DataVisualizerUserState.cs
+++ b/Editor/DataVisualizer/Data/DataVisualizerUserState.cs
@@ -67,24 +67,52 @@ namespace WallstopStudios.DataVisualizer.Editor.Data
             return entry.ObjectGuids;
         }
 
-        public void SetLastObjectForType(string typeName, string guid)
+        public bool SetLastObjectForType(string typeName, string guid)
         {
             if (string.IsNullOrWhiteSpace(typeName))
             {
-                return;
+                return false;
             }
 
-            if (string.IsNullOrWhiteSpace(guid))
-            {
-                return;
-            }
-
-            lastObjectSelections.RemoveAll(e =>
+            lastObjectSelections ??= new List<LastObjectSelectionEntry>();
+            int existingIndex = lastObjectSelections.FindIndex(e =>
                 string.Equals(e.typeFullName, typeName, StringComparison.Ordinal)
             );
-            lastObjectSelections.Add(
-                new LastObjectSelectionEntry { typeFullName = typeName, objectGuid = guid }
-            );
+            if (string.IsNullOrWhiteSpace(guid))
+            {
+                if (existingIndex < 0)
+                {
+                    return false;
+                }
+
+                lastObjectSelections.RemoveAt(existingIndex);
+                return true;
+            }
+
+            if (
+                existingIndex >= 0
+                && string.Equals(
+                    lastObjectSelections[existingIndex].objectGuid,
+                    guid,
+                    StringComparison.Ordinal
+                )
+            )
+            {
+                return false;
+            }
+
+            if (existingIndex >= 0)
+            {
+                lastObjectSelections[existingIndex].objectGuid = guid;
+            }
+            else
+            {
+                lastObjectSelections.Add(
+                    new LastObjectSelectionEntry { typeFullName = typeName, objectGuid = guid }
+                );
+            }
+
+            return true;
         }
 
         public string GetLastObjectForType(string typeName)
@@ -95,7 +123,7 @@ namespace WallstopStudios.DataVisualizer.Editor.Data
             }
 
             return lastObjectSelections
-                .Find(e => string.Equals(e.typeFullName, typeName, StringComparison.Ordinal))
+                ?.Find(e => string.Equals(e.typeFullName, typeName, StringComparison.Ordinal))
                 ?.objectGuid;
         }
 

--- a/Editor/DataVisualizer/Data/DataVisualizerUserState.cs
+++ b/Editor/DataVisualizer/Data/DataVisualizerUserState.cs
@@ -33,16 +33,16 @@ namespace WallstopStudios.DataVisualizer.Editor.Data
             }
 
             DataVisualizerUserState userState = JsonUtility.FromJson<DataVisualizerUserState>(json);
-            if (
-                userState == null
-                || json.Contains("\"lastSelectedTypeFullName\"", StringComparison.Ordinal)
-            )
+            if (userState == null)
             {
                 return userState;
             }
 
             LegacyUserState legacyUserState = JsonUtility.FromJson<LegacyUserState>(json);
-            if (!string.IsNullOrWhiteSpace(legacyUserState?.lastSelectedTypeName))
+            if (
+                string.IsNullOrWhiteSpace(userState.lastSelectedTypeFullName)
+                && !string.IsNullOrWhiteSpace(legacyUserState?.lastSelectedTypeName)
+            )
             {
                 userState.lastSelectedTypeFullName = legacyUserState.lastSelectedTypeName;
             }

--- a/Editor/DataVisualizer/Data/DataVisualizerUserState.cs
+++ b/Editor/DataVisualizer/Data/DataVisualizerUserState.cs
@@ -67,16 +67,16 @@ namespace WallstopStudios.DataVisualizer.Editor.Data
             return entry.ObjectGuids;
         }
 
-        public bool SetLastObjectForType(string typeName, string guid)
+        public bool SetLastObjectForType(string typeFullName, string guid)
         {
-            if (string.IsNullOrWhiteSpace(typeName))
+            if (string.IsNullOrWhiteSpace(typeFullName))
             {
                 return false;
             }
 
             lastObjectSelections ??= new List<LastObjectSelectionEntry>();
             int existingIndex = lastObjectSelections.FindIndex(e =>
-                string.Equals(e.typeFullName, typeName, StringComparison.Ordinal)
+                string.Equals(e.typeFullName, typeFullName, StringComparison.Ordinal)
             );
             if (string.IsNullOrWhiteSpace(guid))
             {
@@ -108,22 +108,22 @@ namespace WallstopStudios.DataVisualizer.Editor.Data
             else
             {
                 lastObjectSelections.Add(
-                    new LastObjectSelectionEntry { typeFullName = typeName, objectGuid = guid }
+                    new LastObjectSelectionEntry { typeFullName = typeFullName, objectGuid = guid }
                 );
             }
 
             return true;
         }
 
-        public string GetLastObjectForType(string typeName)
+        public string GetLastObjectForType(string typeFullName)
         {
-            if (string.IsNullOrWhiteSpace(typeName))
+            if (string.IsNullOrWhiteSpace(typeFullName))
             {
                 return null;
             }
 
             return lastObjectSelections
-                ?.Find(e => string.Equals(e.typeFullName, typeName, StringComparison.Ordinal))
+                ?.Find(e => string.Equals(e.typeFullName, typeFullName, StringComparison.Ordinal))
                 ?.objectGuid;
         }
 

--- a/Editor/DataVisualizer/Data/DataVisualizerUserState.cs
+++ b/Editor/DataVisualizer/Data/DataVisualizerUserState.cs
@@ -122,6 +122,26 @@ namespace WallstopStudios.DataVisualizer.Editor.Data
             return entry != null;
         }
 
+        public bool SetNamespaceCollapsed(string namespaceKey, bool isCollapsed)
+        {
+            if (string.IsNullOrWhiteSpace(namespaceKey))
+            {
+                return false;
+            }
+
+            namespaceCollapseStates ??= new List<NamespaceCollapseState>();
+            return NamespaceCollapseState.SetCollapsed(
+                namespaceCollapseStates,
+                namespaceKey,
+                isCollapsed
+            );
+        }
+
+        public bool RemoveNamespaceCollapseState(string namespaceKey)
+        {
+            return NamespaceCollapseState.Remove(namespaceCollapseStates, namespaceKey);
+        }
+
         public NamespaceCollapseState GetOrCreateCollapseState(string namespaceKey)
         {
             NamespaceCollapseState entry = namespaceCollapseStates.Find(o =>

--- a/Editor/DataVisualizer/Data/DataVisualizerUserState.cs
+++ b/Editor/DataVisualizer/Data/DataVisualizerUserState.cs
@@ -3,12 +3,16 @@ namespace WallstopStudios.DataVisualizer.Editor.Data
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using UnityEngine;
+    using UnityEngine.Serialization;
 
     [Serializable]
     public sealed class DataVisualizerUserState
     {
         public string lastSelectedNamespaceKey = string.Empty;
-        public string lastSelectedTypeName = string.Empty;
+
+        [FormerlySerializedAs("lastSelectedTypeName")]
+        public string lastSelectedTypeFullName = string.Empty;
 
         public List<string> namespaceOrder = new();
         public List<NamespaceTypeOrder> typeOrders = new();
@@ -21,6 +25,31 @@ namespace WallstopStudios.DataVisualizer.Editor.Data
         public List<TypeLabelFilterConfig> labelFilterConfigs = new();
         public List<ProcessorState> processorStates = new();
 
+        public static DataVisualizerUserState FromJson(string json)
+        {
+            if (string.IsNullOrWhiteSpace(json))
+            {
+                return null;
+            }
+
+            DataVisualizerUserState userState = JsonUtility.FromJson<DataVisualizerUserState>(json);
+            if (
+                userState == null
+                || json.Contains("\"lastSelectedTypeFullName\"", StringComparison.Ordinal)
+            )
+            {
+                return userState;
+            }
+
+            LegacyUserState legacyUserState = JsonUtility.FromJson<LegacyUserState>(json);
+            if (!string.IsNullOrWhiteSpace(legacyUserState?.lastSelectedTypeName))
+            {
+                userState.lastSelectedTypeFullName = legacyUserState.lastSelectedTypeName;
+            }
+
+            return userState;
+        }
+
         public void HydrateFrom(DataVisualizerSettings settings)
         {
             if (settings == null)
@@ -29,7 +58,7 @@ namespace WallstopStudios.DataVisualizer.Editor.Data
             }
 
             lastSelectedNamespaceKey = settings.lastSelectedNamespaceKey;
-            lastSelectedTypeName = settings.lastSelectedTypeName;
+            lastSelectedTypeFullName = settings.lastSelectedTypeFullName;
             namespaceOrder = settings.namespaceOrder?.ToList() ?? new List<string>();
             typeOrders =
                 settings.typeOrders?.Select(order => order.Clone()).ToList()
@@ -183,6 +212,12 @@ namespace WallstopStudios.DataVisualizer.Editor.Data
             entry = new NamespaceCollapseState { namespaceKey = namespaceKey, isCollapsed = false };
             namespaceCollapseStates.Add(entry);
             return entry;
+        }
+
+        [Serializable]
+        private sealed class LegacyUserState
+        {
+            public string lastSelectedTypeName;
         }
     }
 }

--- a/Editor/DataVisualizer/Data/NamespaceCollapseState.cs
+++ b/Editor/DataVisualizer/Data/NamespaceCollapseState.cs
@@ -1,12 +1,60 @@
 namespace WallstopStudios.DataVisualizer.Editor.Data
 {
     using System;
+    using System.Collections.Generic;
 
     [Serializable]
     public sealed class NamespaceCollapseState
     {
         public string namespaceKey = string.Empty;
         public bool isCollapsed;
+
+        public static bool SetCollapsed(
+            List<NamespaceCollapseState> states,
+            string namespaceKey,
+            bool isCollapsed
+        )
+        {
+            if (states == null || string.IsNullOrWhiteSpace(namespaceKey))
+            {
+                return false;
+            }
+
+            NamespaceCollapseState entry = states.Find(state =>
+                string.Equals(state?.namespaceKey, namespaceKey, StringComparison.Ordinal)
+            );
+            if (entry == null)
+            {
+                states.Add(
+                    new NamespaceCollapseState
+                    {
+                        namespaceKey = namespaceKey,
+                        isCollapsed = isCollapsed,
+                    }
+                );
+                return true;
+            }
+
+            if (entry.isCollapsed == isCollapsed)
+            {
+                return false;
+            }
+
+            entry.isCollapsed = isCollapsed;
+            return true;
+        }
+
+        public static bool Remove(List<NamespaceCollapseState> states, string namespaceKey)
+        {
+            if (states == null || string.IsNullOrWhiteSpace(namespaceKey))
+            {
+                return false;
+            }
+
+            return states.RemoveAll(state =>
+                    string.Equals(state?.namespaceKey, namespaceKey, StringComparison.Ordinal)
+                ) > 0;
+        }
 
         public NamespaceCollapseState Clone()
         {

--- a/Editor/DataVisualizer/Data/NamespaceTypeOrder.cs
+++ b/Editor/DataVisualizer/Data/NamespaceTypeOrder.cs
@@ -10,6 +10,72 @@ namespace WallstopStudios.DataVisualizer.Editor.Data
         public string namespaceKey = string.Empty;
         public List<string> typeNames = new();
 
+        public static int CompareTypesByFullNameOrder(
+            Type lhs,
+            Type rhs,
+            IReadOnlyList<string> typeFullNameOrder
+        )
+        {
+            return CompareTypeFullNames(
+                lhs?.FullName ?? string.Empty,
+                rhs?.FullName ?? string.Empty,
+                typeFullNameOrder
+            );
+        }
+
+        public static int CompareTypesByFullName(Type lhs, Type rhs)
+        {
+            return string.Compare(
+                lhs?.FullName ?? string.Empty,
+                rhs?.FullName ?? string.Empty,
+                StringComparison.Ordinal
+            );
+        }
+
+        public static int CompareTypesByNameThenFullName(Type lhs, Type rhs)
+        {
+            int nameComparison = string.Compare(
+                lhs?.Name ?? string.Empty,
+                rhs?.Name ?? string.Empty,
+                StringComparison.Ordinal
+            );
+            return nameComparison != 0 ? nameComparison : CompareTypesByFullName(lhs, rhs);
+        }
+
+        public static int CompareTypeFullNames(
+            string lhsFullName,
+            string rhsFullName,
+            IReadOnlyList<string> typeFullNameOrder
+        )
+        {
+            int indexA = IndexOf(typeFullNameOrder, lhsFullName);
+            int indexB = IndexOf(typeFullNameOrder, rhsFullName);
+
+            switch (indexA)
+            {
+                case >= 0 when indexB >= 0:
+                    return indexA.CompareTo(indexB);
+                case >= 0:
+                    return -1;
+            }
+
+            return 0 <= indexB
+                ? 1
+                : string.Compare(lhsFullName, rhsFullName, StringComparison.Ordinal);
+        }
+
+        public static Type FindTypeByFullName(IEnumerable<Type> types, string typeFullName)
+        {
+            if (types == null || string.IsNullOrWhiteSpace(typeFullName))
+            {
+                return null;
+            }
+
+            return types.FirstOrDefault(type =>
+                string.Equals(type?.FullName, typeFullName, StringComparison.Ordinal)
+            );
+        }
+
         public NamespaceTypeOrder Clone()
         {
             return new NamespaceTypeOrder
@@ -17,6 +83,24 @@ namespace WallstopStudios.DataVisualizer.Editor.Data
                 namespaceKey = namespaceKey ?? string.Empty,
                 typeNames = typeNames?.ToList() ?? new List<string>(),
             };
+        }
+
+        private static int IndexOf(IReadOnlyList<string> values, string value)
+        {
+            if (values == null || string.IsNullOrWhiteSpace(value))
+            {
+                return -1;
+            }
+
+            for (int i = 0; i < values.Count; ++i)
+            {
+                if (string.Equals(values[i], value, StringComparison.Ordinal))
+                {
+                    return i;
+                }
+            }
+
+            return -1;
         }
     }
 }

--- a/Editor/DataVisualizer/DataVisualizer.cs
+++ b/Editor/DataVisualizer/DataVisualizer.cs
@@ -1147,7 +1147,7 @@ namespace WallstopStudios.DataVisualizer.Editor
                 _scriptableObjectTypes,
                 _namespaceOrder,
                 GetLastSelectedNamespaceKey(),
-                GetLastSelectedTypeName()
+                GetLastSelectedTypeFullName()
             );
 
             if (selectedType == null)
@@ -9138,7 +9138,7 @@ namespace WallstopStudios.DataVisualizer.Editor
             );
         }
 
-        private string GetLastSelectedTypeName()
+        private string GetLastSelectedTypeFullName()
         {
             DataVisualizerSettings settings = Settings;
             return settings.persistStateInSettingsAsset
@@ -9146,29 +9146,29 @@ namespace WallstopStudios.DataVisualizer.Editor
                 : UserState.lastSelectedTypeName;
         }
 
-        private string GetLastSelectedObjectGuidForType(string typeName)
+        private string GetLastSelectedObjectGuidForType(string typeFullName)
         {
-            if (string.IsNullOrWhiteSpace(typeName))
+            if (string.IsNullOrWhiteSpace(typeFullName))
             {
                 return null;
             }
 
             DataVisualizerSettings settings = Settings;
             return settings.persistStateInSettingsAsset
-                ? settings.GetLastObjectForType(typeName)
-                : UserState.GetLastObjectForType(typeName);
+                ? settings.GetLastObjectForType(typeFullName)
+                : UserState.GetLastObjectForType(typeFullName);
         }
 
-        internal void SetLastSelectedObjectGuidForType(string typeName, string objectGuid)
+        internal void SetLastSelectedObjectGuidForType(string typeFullName, string objectGuid)
         {
-            if (string.IsNullOrWhiteSpace(typeName))
+            if (string.IsNullOrWhiteSpace(typeFullName))
             {
                 return;
             }
 
             PersistSettings(
-                settings => settings.SetLastObjectForType(typeName, objectGuid),
-                userState => userState.SetLastObjectForType(typeName, objectGuid)
+                settings => settings.SetLastObjectForType(typeFullName, objectGuid),
+                userState => userState.SetLastObjectForType(typeFullName, objectGuid)
             );
         }
 

--- a/Editor/DataVisualizer/DataVisualizer.cs
+++ b/Editor/DataVisualizer/DataVisualizer.cs
@@ -42,9 +42,7 @@ namespace WallstopStudios.DataVisualizer.Editor
         private const string SettingsDefaultPath = "Assets/Editor/DataVisualizerSettings.asset";
         private const string UserStateFileName = "DataVisualizerUserState.json";
 
-        private const string NamespaceItemClass = "namespace-item";
         private const string NamespaceGroupHeaderClass = "namespace-group-header";
-        private const string NamespaceIndicatorClass = "namespace-indicator";
         private const string ObjectItemClass = "object-item";
         private const string ObjectItemContentClass = "object-item-content";
         private const string ObjectItemActionsClass = "object-item-actions";
@@ -802,36 +800,12 @@ namespace WallstopStudios.DataVisualizer.Editor
 
             LoadScriptableObjectTypes();
 
-            int namespaceIndex = -1;
-            if (!string.IsNullOrWhiteSpace(previousNamespaceKey))
-            {
-                namespaceIndex = _namespaceOrder.GetValueOrDefault(previousNamespaceKey, -1);
-            }
-
-            if (namespaceIndex < 0 && 0 < _scriptableObjectTypes.Count)
-            {
-                namespaceIndex = 0;
-            }
-
-            if (0 <= namespaceIndex)
-            {
-                List<Type> typesInNamespace = _scriptableObjectTypes.GetValueOrDefault(
-                    previousNamespaceKey,
-                    null
-                );
-                if (0 < typesInNamespace?.Count)
-                {
-                    if (!string.IsNullOrWhiteSpace(previousTypeFullName))
-                    {
-                        selectedType = NamespaceTypeOrder.FindTypeByFullName(
-                            typesInNamespace,
-                            previousTypeFullName
-                        );
-                    }
-
-                    selectedType ??= typesInNamespace[0];
-                }
-            }
+            selectedType = ResolveSelectedTypeByFullName(
+                _scriptableObjectTypes,
+                _namespaceOrder,
+                previousNamespaceKey,
+                previousTypeFullName
+            );
 
             // Load once. For an unchanged type the SelectType call near the end no-ops its own load,
             // so reload here (a refresh must re-scan). For a changed type, let that single SelectType
@@ -908,15 +882,23 @@ namespace WallstopStudios.DataVisualizer.Editor
 
         private VisualElement FindAncestorNamespaceGroup(VisualElement startingElement)
         {
+            return FindAncestorNamespaceGroup(startingElement, _namespaceListContainer);
+        }
+
+        public static VisualElement FindAncestorNamespaceGroup(
+            VisualElement startingElement,
+            VisualElement namespaceListContainer
+        )
+        {
             if (startingElement == null)
             {
                 return null;
             }
 
             VisualElement currentElement = startingElement;
-            while (currentElement != null && currentElement != _namespaceListContainer)
+            while (currentElement != null && currentElement != namespaceListContainer)
             {
-                if (currentElement.ClassListContains("object-item"))
+                if (currentElement.ClassListContains(StyleConstants.NamespaceItemClass))
                 {
                     return currentElement;
                 }
@@ -925,6 +907,107 @@ namespace WallstopStudios.DataVisualizer.Editor
             }
 
             return null;
+        }
+
+        public static string FindFirstNamespaceKeyByOrder(
+            IReadOnlyDictionary<string, int> namespaceOrder
+        )
+        {
+            if (namespaceOrder == null || namespaceOrder.Count == 0)
+            {
+                return null;
+            }
+
+            string firstNamespaceKey = null;
+            int firstNamespaceIndex = int.MaxValue;
+            foreach (KeyValuePair<string, int> entry in namespaceOrder)
+            {
+                if (
+                    entry.Value < firstNamespaceIndex
+                    || (
+                        entry.Value == firstNamespaceIndex
+                        && (
+                            firstNamespaceKey == null
+                            || string.CompareOrdinal(entry.Key, firstNamespaceKey) < 0
+                        )
+                    )
+                )
+                {
+                    firstNamespaceKey = entry.Key;
+                    firstNamespaceIndex = entry.Value;
+                }
+            }
+
+            return firstNamespaceKey;
+        }
+
+        public static Type ResolveSelectedTypeByFullName(
+            IReadOnlyDictionary<string, List<Type>> typesByNamespace,
+            IReadOnlyDictionary<string, int> namespaceOrder,
+            string savedNamespaceKey,
+            string savedTypeFullName
+        )
+        {
+            if (typesByNamespace == null || typesByNamespace.Count == 0)
+            {
+                return null;
+            }
+
+            if (!string.IsNullOrWhiteSpace(savedTypeFullName))
+            {
+                Type savedType = NamespaceTypeOrder.FindTypeByFullName(
+                    typesByNamespace.Values.SelectMany(types => types ?? Enumerable.Empty<Type>()),
+                    savedTypeFullName
+                );
+                if (savedType != null)
+                {
+                    return savedType;
+                }
+            }
+
+            if (
+                !string.IsNullOrWhiteSpace(savedNamespaceKey)
+                && typesByNamespace.TryGetValue(savedNamespaceKey, out List<Type> savedTypes)
+                && savedTypes is { Count: > 0 }
+            )
+            {
+                return savedTypes[0];
+            }
+
+            string firstOrderedNamespaceKey = FindFirstNamespaceKeyByOrder(namespaceOrder);
+            if (
+                !string.IsNullOrWhiteSpace(firstOrderedNamespaceKey)
+                && typesByNamespace.TryGetValue(
+                    firstOrderedNamespaceKey,
+                    out List<Type> firstOrderedTypes
+                )
+                && firstOrderedTypes is { Count: > 0 }
+            )
+            {
+                return firstOrderedTypes[0];
+            }
+
+            foreach (
+                string namespaceKey in (namespaceOrder ?? new Dictionary<string, int>())
+                    .OrderBy(entry => entry.Value)
+                    .ThenBy(entry => entry.Key, StringComparer.Ordinal)
+                    .Select(entry => entry.Key)
+            )
+            {
+                if (
+                    typesByNamespace.TryGetValue(namespaceKey, out List<Type> orderedTypes)
+                    && orderedTypes is { Count: > 0 }
+                )
+                {
+                    return orderedTypes[0];
+                }
+            }
+
+            return typesByNamespace
+                .OrderBy(entry => entry.Key, StringComparer.Ordinal)
+                .Select(entry => entry.Value)
+                .FirstOrDefault(types => types is { Count: > 0 })
+                ?.FirstOrDefault();
         }
 
         private void ExpandNamespaceGroupIfNeeded(VisualElement namespaceGroupItem, bool saveState)
@@ -1060,57 +1143,17 @@ namespace WallstopStudios.DataVisualizer.Editor
                 return;
             }
 
-            string savedNamespaceKey = GetLastSelectedNamespaceKey();
-            List<Type> typesInNamespace;
-            int namespaceIndex = -1;
+            Type selectedType = ResolveSelectedTypeByFullName(
+                _scriptableObjectTypes,
+                _namespaceOrder,
+                GetLastSelectedNamespaceKey(),
+                GetLastSelectedTypeName()
+            );
 
-            if (!string.IsNullOrWhiteSpace(savedNamespaceKey))
-            {
-                namespaceIndex = _namespaceOrder.GetValueOrDefault(savedNamespaceKey, -1);
-            }
-
-            if (0 <= namespaceIndex)
-            {
-                typesInNamespace = _scriptableObjectTypes.GetValueOrDefault(
-                    savedNamespaceKey,
-                    null
-                );
-            }
-            else if (0 < _namespaceOrder.Count)
-            {
-                int bestIndex = _scriptableObjectTypes.Count;
-                string bestNamespace = null;
-                foreach (KeyValuePair<string, int> entry in _namespaceOrder)
-                {
-                    if (entry.Value < bestIndex)
-                    {
-                        bestNamespace = entry.Key;
-                    }
-                }
-
-                typesInNamespace = _scriptableObjectTypes.GetValueOrDefault(bestNamespace, null);
-            }
-            else
-            {
-                typesInNamespace = null;
-            }
-
-            if (typesInNamespace is not { Count: > 0 })
+            if (selectedType == null)
             {
                 return;
             }
-
-            string savedTypeName = GetLastSelectedTypeName();
-            Type selectedType = null;
-
-            if (!string.IsNullOrWhiteSpace(savedTypeName))
-            {
-                selectedType = typesInNamespace.Find(t =>
-                    string.Equals(t.FullName, savedTypeName, StringComparison.Ordinal)
-                );
-            }
-
-            selectedType ??= typesInNamespace[0];
 
             // Build namespace view first so type selection is visible
             BuildNamespaceView();
@@ -1125,34 +1168,10 @@ namespace WallstopStudios.DataVisualizer.Editor
             VisualElement typeElementToSelect = FindTypeElement(selectedType);
             if (typeElementToSelect != null)
             {
-                VisualElement ancestorGroup = null;
-                VisualElement currentElement = typeElementToSelect;
-                while (currentElement != null && currentElement != _namespaceListContainer)
-                {
-                    if (currentElement.ClassListContains(NamespaceItemClass))
-                    {
-                        ancestorGroup = currentElement;
-                        break;
-                    }
-
-                    currentElement = currentElement.parent;
-                }
-
+                VisualElement ancestorGroup = FindAncestorNamespaceGroup(typeElementToSelect);
                 if (ancestorGroup != null)
                 {
-                    Label indicator = ancestorGroup.Q<Label>(className: NamespaceIndicatorClass);
-                    VisualElement typesContainer = ancestorGroup.Q<VisualElement>(
-                        $"types-container-{ancestorGroup.userData as string}"
-                    );
-
-                    if (
-                        indicator != null
-                        && typesContainer != null
-                        && typesContainer.style.display == DisplayStyle.None
-                    )
-                    {
-                        ApplyNamespaceCollapsedState(indicator, typesContainer, false, false);
-                    }
+                    ExpandNamespaceGroupIfNeeded(ancestorGroup, false);
                 }
             }
         }
@@ -4002,10 +4021,23 @@ namespace WallstopStudios.DataVisualizer.Editor
             _filteredObjects.RemoveAll(obj => obj == null);
             _selectedObjectOrderIndex.Remove(objectToDelete);
             int targetIndex = _selectedObject == objectToDelete ? Mathf.Max(0, index - 1) : 0;
+            string deletedTypeFullName = objectToDelete.GetType().FullName;
+            string deletedGuid = AssetDatabase.AssetPathToGUID(path);
 
             bool deleted = AssetDatabase.DeleteAsset(path);
             if (deleted)
             {
+                if (
+                    string.Equals(
+                        GetLastSelectedObjectGuidForType(deletedTypeFullName),
+                        deletedGuid,
+                        StringComparison.OrdinalIgnoreCase
+                    )
+                )
+                {
+                    SetLastSelectedObjectGuidForType(deletedTypeFullName, null);
+                }
+
                 Debug.Log($"Asset '{path}' deleted successfully.");
                 AssetDatabase.Refresh();
                 BuildObjectsView();
@@ -7513,7 +7545,17 @@ namespace WallstopStudios.DataVisualizer.Editor
             string savedObjectGuid = GetLastSelectedObjectGuidForType(type.FullName);
 
             // Get all GUIDs for this type
-            string[] allGuids = AssetDatabase.FindAssets($"t:{type.Name}");
+            string[] allGuids = IncludeResolvedSavedObjectGuid(
+                type,
+                savedObjectGuid,
+                AssetDatabase.FindAssets($"t:{type.Name}"),
+                out string normalizedSavedObjectGuid
+            );
+            if (!string.IsNullOrWhiteSpace(savedObjectGuid) && normalizedSavedObjectGuid == null)
+            {
+                SetLastSelectedObjectGuidForType(type.FullName, null);
+            }
+            savedObjectGuid = normalizedSavedObjectGuid;
             _asyncLoadTotalCount = allGuids.Length;
             _asyncLoadSkippedCount = 0;
 
@@ -7529,18 +7571,6 @@ namespace WallstopStudios.DataVisualizer.Editor
                 SelectObject(null);
                 BuildObjectsView();
                 return;
-            }
-
-            // Ignore a stale saved selection (asset deleted/moved so FindAssets no longer returns it)
-            // so it isn't prioritized ahead of real assets, wasting a priority slot loading nothing.
-            // Case-insensitive so a valid saved GUID is never dropped over casing and then wrongly
-            // de-prioritized (which would fall back to the first asset and overwrite the saved id).
-            if (
-                !string.IsNullOrWhiteSpace(savedObjectGuid)
-                && !allGuids.Contains(savedObjectGuid, StringComparer.OrdinalIgnoreCase)
-            )
-            {
-                savedObjectGuid = null;
             }
 
             // Establish the canonical display order for this load: custom-ordered assets first (in
@@ -7857,6 +7887,70 @@ namespace WallstopStudios.DataVisualizer.Editor
             {
                 BuildObjectsView();
             }
+        }
+
+        public static bool TryResolveAssetGuidForType(
+            string assetGuid,
+            Type type,
+            out string assetPath
+        )
+        {
+            assetPath = null;
+            if (string.IsNullOrWhiteSpace(assetGuid) || type == null)
+            {
+                return false;
+            }
+
+            assetPath = AssetDatabase.GUIDToAssetPath(assetGuid);
+            if (string.IsNullOrWhiteSpace(assetPath))
+            {
+                assetPath = null;
+                return false;
+            }
+
+            ScriptableObject asset =
+                AssetDatabase.LoadMainAssetAtPath(assetPath) as ScriptableObject;
+            if (asset == null || asset.GetType() != type)
+            {
+                assetPath = null;
+                return false;
+            }
+
+            return true;
+        }
+
+        public static string[] IncludeResolvedSavedObjectGuid(
+            Type type,
+            string savedObjectGuid,
+            IEnumerable<string> discoveredGuids,
+            out string normalizedSavedObjectGuid
+        )
+        {
+            normalizedSavedObjectGuid = null;
+            string[] guids =
+                discoveredGuids?.Where(guid => !string.IsNullOrWhiteSpace(guid)).ToArray()
+                ?? Array.Empty<string>();
+
+            string matchingGuid = guids.FirstOrDefault(guid =>
+                string.Equals(guid, savedObjectGuid, StringComparison.OrdinalIgnoreCase)
+            );
+            string guidToResolve = !string.IsNullOrWhiteSpace(matchingGuid)
+                ? matchingGuid
+                : savedObjectGuid;
+
+            if (!TryResolveAssetGuidForType(guidToResolve, type, out _))
+            {
+                return guids;
+            }
+
+            if (!string.IsNullOrWhiteSpace(matchingGuid))
+            {
+                normalizedSavedObjectGuid = matchingGuid;
+                return guids;
+            }
+
+            normalizedSavedObjectGuid = guidToResolve;
+            return guids.Append(guidToResolve).ToArray();
         }
 
         private void ContinueLoadingObjects(Type type, int loadGeneration)
@@ -9073,16 +9167,8 @@ namespace WallstopStudios.DataVisualizer.Editor
             }
 
             PersistSettings(
-                settings =>
-                {
-                    settings.SetLastObjectForType(typeName, objectGuid);
-                    return true;
-                },
-                userState =>
-                {
-                    userState.SetLastObjectForType(typeName, objectGuid);
-                    return true;
-                }
+                settings => settings.SetLastObjectForType(typeName, objectGuid),
+                userState => userState.SetLastObjectForType(typeName, objectGuid)
             );
         }
 

--- a/Editor/DataVisualizer/DataVisualizer.cs
+++ b/Editor/DataVisualizer/DataVisualizer.cs
@@ -7934,23 +7934,21 @@ namespace WallstopStudios.DataVisualizer.Editor
             string matchingGuid = guids.FirstOrDefault(guid =>
                 string.Equals(guid, savedObjectGuid, StringComparison.OrdinalIgnoreCase)
             );
-            string guidToResolve = !string.IsNullOrWhiteSpace(matchingGuid)
-                ? matchingGuid
-                : savedObjectGuid;
-
-            if (!TryResolveAssetGuidForType(guidToResolve, type, out _))
-            {
-                return guids;
-            }
-
             if (!string.IsNullOrWhiteSpace(matchingGuid))
             {
-                normalizedSavedObjectGuid = matchingGuid;
+                normalizedSavedObjectGuid = NormalizeSavedObjectGuidForType(matchingGuid, type);
                 return guids;
             }
 
-            normalizedSavedObjectGuid = guidToResolve;
-            return guids.Append(guidToResolve).ToArray();
+            normalizedSavedObjectGuid = NormalizeSavedObjectGuidForType(savedObjectGuid, type);
+            return normalizedSavedObjectGuid == null
+                ? guids
+                : guids.Append(normalizedSavedObjectGuid).ToArray();
+        }
+
+        private static string NormalizeSavedObjectGuidForType(string assetGuid, Type type)
+        {
+            return TryResolveAssetGuidForType(assetGuid, type, out _) ? assetGuid : null;
         }
 
         private void ContinueLoadingObjects(Type type, int loadGeneration)

--- a/Editor/DataVisualizer/DataVisualizer.cs
+++ b/Editor/DataVisualizer/DataVisualizer.cs
@@ -8913,7 +8913,7 @@ namespace WallstopStudios.DataVisualizer.Editor
                 try
                 {
                     string json = File.ReadAllText(_userStateFilePath);
-                    _userState = JsonUtility.FromJson<DataVisualizerUserState>(json);
+                    _userState = DataVisualizerUserState.FromJson(json);
                     if (_userState == null)
                     {
                         Debug.LogWarning(
@@ -9142,8 +9142,8 @@ namespace WallstopStudios.DataVisualizer.Editor
         {
             DataVisualizerSettings settings = Settings;
             return settings.persistStateInSettingsAsset
-                ? settings.lastSelectedTypeName
-                : UserState.lastSelectedTypeName;
+                ? settings.lastSelectedTypeFullName
+                : UserState.lastSelectedTypeFullName;
         }
 
         private string GetLastSelectedObjectGuidForType(string typeFullName)

--- a/Editor/DataVisualizer/DataVisualizer.cs
+++ b/Editor/DataVisualizer/DataVisualizer.cs
@@ -789,7 +789,7 @@ namespace WallstopStudios.DataVisualizer.Editor
                 selectedType != null
                     ? NamespaceController.GetNamespaceKey(selectedType)
                     : string.Empty;
-            string previousTypeName = selectedType?.Name;
+            string previousTypeFullName = selectedType?.FullName;
             string previousObjectGuid = null;
             if (_selectedObject != null)
             {
@@ -821,10 +821,11 @@ namespace WallstopStudios.DataVisualizer.Editor
                 );
                 if (0 < typesInNamespace?.Count)
                 {
-                    if (!string.IsNullOrWhiteSpace(previousTypeName))
+                    if (!string.IsNullOrWhiteSpace(previousTypeFullName))
                     {
-                        selectedType = typesInNamespace.Find(t =>
-                            string.Equals(t.Name, previousTypeName, StringComparison.Ordinal)
+                        selectedType = NamespaceTypeOrder.FindTypeByFullName(
+                            typesInNamespace,
+                            previousTypeFullName
                         );
                     }
 
@@ -4167,6 +4168,7 @@ namespace WallstopStudios.DataVisualizer.Editor
                     .Where(type => !currentlyManagedTypes.Contains(type))
                     .Distinct()
                     .ToList();
+                scriptableObjectTypes.Sort(NamespaceTypeOrder.CompareTypesByFullName);
 
                 bool stateChanged = false;
                 foreach (Type typeToAdd in scriptableObjectTypes)
@@ -4257,8 +4259,8 @@ namespace WallstopStudios.DataVisualizer.Editor
                     .Where(IsLoadableType)
                     .Where(type => !currentlyManagedTypes.Contains(type))
                     .Distinct()
-                    .OrderBy(type => type.Name)
                     .ToList();
+                scriptableObjectTypes.Sort(NamespaceTypeOrder.CompareTypesByFullName);
 
                 bool stateChanged = false;
                 foreach (Type typeToAdd in scriptableObjectTypes)
@@ -4341,7 +4343,7 @@ namespace WallstopStudios.DataVisualizer.Editor
 
                 HashSet<string> managedTypeFullNames = _namespaceController
                     .GetAllManagedTypeNames()
-                    .ToHashSet(StringComparer.OrdinalIgnoreCase);
+                    .ToHashSet(StringComparer.Ordinal);
 
                 IOrderedEnumerable<IGrouping<string, Type>> groupedTypes =
                     LoadRelevantScriptableObjectTypes()
@@ -4353,6 +4355,8 @@ namespace WallstopStudios.DataVisualizer.Editor
                 foreach (IGrouping<string, Type> group in groupedTypes)
                 {
                     string namespaceKey = group.Key;
+                    List<Type> orderedGroupTypes = group.ToList();
+                    orderedGroupTypes.Sort(NamespaceTypeOrder.CompareTypesByNameThenFullName);
                     List<Type> addableTypes = new();
                     List<VisualElement> typesToShowInGroup = new();
 
@@ -4362,7 +4366,7 @@ namespace WallstopStudios.DataVisualizer.Editor
                             namespaceKey.Contains(term, StringComparison.OrdinalIgnoreCase)
                         );
 
-                    foreach (Type type in group.OrderBy(t => t.Name))
+                    foreach (Type type in orderedGroupTypes)
                     {
                         string typeName = type.Name;
                         bool typeMatchesSearch =
@@ -4398,7 +4402,7 @@ namespace WallstopStudios.DataVisualizer.Editor
                             header.AddToClassList(StyleConstants.ExpandedClass);
                         }
 
-                        foreach (Type type in group.OrderBy(t => t.Name))
+                        foreach (Type type in orderedGroupTypes)
                         {
                             string typeName = type.Name;
                             bool typeMatchesSearch =
@@ -7942,16 +7946,16 @@ namespace WallstopStudios.DataVisualizer.Editor
                 managedTypeFullNames =
                     settings
                         .typeOrders?.SelectMany(order => order.typeNames)
-                        .ToHashSet(StringComparer.OrdinalIgnoreCase)
-                    ?? new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                        .ToHashSet(StringComparer.Ordinal)
+                    ?? new HashSet<string>(StringComparer.Ordinal);
             }
             else
             {
                 managedTypeFullNames =
                     UserState
                         .typeOrders?.SelectMany(order => order.typeNames)
-                        .ToHashSet(StringComparer.OrdinalIgnoreCase)
-                    ?? new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                        .ToHashSet(StringComparer.Ordinal)
+                    ?? new HashSet<string>(StringComparer.Ordinal);
             }
 
             List<Type> allObjectTypes = LoadRelevantScriptableObjectTypes();
@@ -7976,9 +7980,14 @@ namespace WallstopStudios.DataVisualizer.Editor
 
             foreach ((string key, List<Type> types) in orderedTypes)
             {
-                List<string> customTypeNameOrder = GetTypeOrderForNamespace(key);
+                List<string> customTypeFullNameOrder = GetTypeOrderForNamespace(key);
                 types.Sort(
-                    (lhs, rhs) => CompareUsingCustomOrder(lhs.Name, rhs.Name, customTypeNameOrder)
+                    (lhs, rhs) =>
+                        NamespaceTypeOrder.CompareTypesByFullNameOrder(
+                            lhs,
+                            rhs,
+                            customTypeFullNameOrder
+                        )
                 );
             }
 

--- a/Editor/DataVisualizer/DataVisualizer.cs
+++ b/Editor/DataVisualizer/DataVisualizer.cs
@@ -767,6 +767,20 @@ namespace WallstopStudios.DataVisualizer.Editor
             }
         }
 
+        public static bool ApplySelectActiveObjectPreference(
+            DataVisualizerSettings settings,
+            bool selectActiveObject
+        )
+        {
+            if (settings == null || !settings.SetSelectActiveObject(selectActiveObject))
+            {
+                return false;
+            }
+
+            AssetDatabase.SaveAssets();
+            return true;
+        }
+
         private void RefreshAllViews()
         {
             Type selectedType = _namespaceController.SelectedType;
@@ -3423,16 +3437,7 @@ namespace WallstopStudios.DataVisualizer.Editor
             selectionToggle.AddToClassList("settings-prefs-toggle");
             selectionToggle.RegisterValueChangedCallback(evt =>
             {
-                bool newSelectActiveObject = evt.newValue;
-                bool previousSelectActiveObject = Settings.selectActiveObject;
-                if (newSelectActiveObject == previousSelectActiveObject)
-                {
-                    return;
-                }
-
-                DataVisualizerSettings localSettings = Settings;
-                localSettings.selectActiveObject = newSelectActiveObject;
-                AssetDatabase.SaveAssets();
+                ApplySelectActiveObjectPreference(Settings, evt.newValue);
             });
             contentWrapper.Add(selectionToggle);
 
@@ -9187,28 +9192,8 @@ namespace WallstopStudios.DataVisualizer.Editor
             }
 
             PersistSettings(
-                settings =>
-                {
-                    NamespaceCollapseState entry = settings.GetOrCreateCollapseState(namespaceKey);
-                    if (entry.isCollapsed == isCollapsed)
-                    {
-                        return false;
-                    }
-
-                    entry.isCollapsed = isCollapsed;
-                    return true;
-                },
-                userState =>
-                {
-                    NamespaceCollapseState entry = userState.GetOrCreateCollapseState(namespaceKey);
-                    if (entry.isCollapsed == isCollapsed)
-                    {
-                        return false;
-                    }
-
-                    entry.isCollapsed = isCollapsed;
-                    return true;
-                }
+                settings => settings.SetNamespaceCollapsed(namespaceKey, isCollapsed),
+                userState => userState.SetNamespaceCollapsed(namespaceKey, isCollapsed)
             );
         }
 

--- a/Editor/DataVisualizer/DataVisualizer.cs
+++ b/Editor/DataVisualizer/DataVisualizer.cs
@@ -7948,7 +7948,13 @@ namespace WallstopStudios.DataVisualizer.Editor
 
         private static string NormalizeSavedObjectGuidForType(string assetGuid, Type type)
         {
-            return TryResolveAssetGuidForType(assetGuid, type, out _) ? assetGuid : null;
+            if (!TryResolveAssetGuidForType(assetGuid, type, out string assetPath))
+            {
+                return null;
+            }
+
+            string canonicalGuid = AssetDatabase.AssetPathToGUID(assetPath);
+            return string.IsNullOrWhiteSpace(canonicalGuid) ? assetGuid : canonicalGuid;
         }
 
         private void ContinueLoadingObjects(Type type, int loadGeneration)

--- a/Editor/DataVisualizer/NamespaceController.cs
+++ b/Editor/DataVisualizer/NamespaceController.cs
@@ -575,7 +575,7 @@ namespace WallstopStudios.DataVisualizer.Editor
                 {
                     if (
                         string.Equals(
-                            settings.lastSelectedTypeName,
+                            settings.lastSelectedTypeFullName,
                             typeFullName,
                             StringComparison.Ordinal
                         )
@@ -583,14 +583,14 @@ namespace WallstopStudios.DataVisualizer.Editor
                     {
                         return false;
                     }
-                    settings.lastSelectedTypeName = typeFullName;
+                    settings.lastSelectedTypeFullName = typeFullName;
                     return true;
                 },
                 userState =>
                 {
                     if (
                         string.Equals(
-                            userState.lastSelectedTypeName,
+                            userState.lastSelectedTypeFullName,
                             typeFullName,
                             StringComparison.Ordinal
                         )
@@ -598,7 +598,7 @@ namespace WallstopStudios.DataVisualizer.Editor
                     {
                         return false;
                     }
-                    userState.lastSelectedTypeName = typeFullName;
+                    userState.lastSelectedTypeFullName = typeFullName;
                     return true;
                 }
             );

--- a/Editor/DataVisualizer/NamespaceController.cs
+++ b/Editor/DataVisualizer/NamespaceController.cs
@@ -737,6 +737,7 @@ namespace WallstopStudios.DataVisualizer.Editor
             }
 
             List<string> currentManagedList = GetManagedTypeNames(namespaceKey);
+            List<string> removedTypeNames = new();
             bool changed = false;
             foreach (Type type in typesToRemove)
             {
@@ -747,6 +748,7 @@ namespace WallstopStudios.DataVisualizer.Editor
                 }
 
                 changed = true;
+                removedTypeNames.Add(typeName);
                 dataVisualizer.SetLastSelectedObjectGuidForType(typeName, null);
                 RemoveTypeOrderEntry(dataVisualizer, namespaceKey, typeName);
             }
@@ -758,7 +760,10 @@ namespace WallstopStudios.DataVisualizer.Editor
                     RemoveNamespaceCollapseState(dataVisualizer, namespaceKey);
                 }
 
-                PersistManagedTypesList(dataVisualizer, currentManagedList);
+                PersistManagedTypesList(
+                    dataVisualizer,
+                    RemoveManagedTypeNames(GetAllManagedTypeNames(), removedTypeNames)
+                );
                 DataVisualizer.SignalRefresh();
             }
             else
@@ -791,7 +796,10 @@ namespace WallstopStudios.DataVisualizer.Editor
                     RemoveNamespaceCollapseState(dataVisualizer, namespaceKey);
                 }
 
-                PersistManagedTypesList(dataVisualizer, currentManagedList);
+                PersistManagedTypesList(
+                    dataVisualizer,
+                    RemoveManagedTypeNames(GetAllManagedTypeNames(), new[] { typeName })
+                );
                 DataVisualizer.SignalRefresh();
             }
             else
@@ -886,6 +894,30 @@ namespace WallstopStudios.DataVisualizer.Editor
         {
             return _managedTypes
                 .Values.SelectMany(types => types.Select(type => type.FullName))
+                .ToList();
+        }
+
+        public static List<string> RemoveManagedTypeNames(
+            IEnumerable<string> managedTypeNames,
+            IEnumerable<string> typeNamesToRemove
+        )
+        {
+            if (managedTypeNames == null)
+            {
+                return new List<string>();
+            }
+
+            HashSet<string> removedTypeNames = typeNamesToRemove
+                ?.Where(typeName => !string.IsNullOrWhiteSpace(typeName))
+                .ToHashSet(StringComparer.Ordinal);
+            if (removedTypeNames == null || removedTypeNames.Count == 0)
+            {
+                return managedTypeNames.ToList();
+            }
+
+            return managedTypeNames
+                .Where(typeName => !removedTypeNames.Contains(typeName))
+                .Distinct(StringComparer.Ordinal)
                 .ToList();
         }
 

--- a/Editor/DataVisualizer/NamespaceController.cs
+++ b/Editor/DataVisualizer/NamespaceController.cs
@@ -692,29 +692,8 @@ namespace WallstopStudios.DataVisualizer.Editor
             }
 
             dataVisualizer.PersistSettings(
-                settings =>
-                {
-                    bool dirty = !settings.HasCollapseState(namespaceKey);
-                    NamespaceCollapseState entry = settings.GetOrCreateCollapseState(namespaceKey);
-                    if (entry.isCollapsed == isCollapsed)
-                    {
-                        dirty = true;
-                    }
-
-                    entry.isCollapsed = isCollapsed;
-                    return dirty;
-                },
-                userState =>
-                {
-                    bool dirty = !userState.HasCollapseState(namespaceKey);
-                    NamespaceCollapseState entry = userState.GetOrCreateCollapseState(namespaceKey);
-                    if (entry.isCollapsed != isCollapsed)
-                    {
-                        dirty = true;
-                    }
-                    entry.isCollapsed = isCollapsed;
-                    return dirty;
-                }
+                settings => settings.SetNamespaceCollapsed(namespaceKey, isCollapsed),
+                userState => userState.SetNamespaceCollapsed(namespaceKey, isCollapsed)
             );
         }
 
@@ -774,6 +753,11 @@ namespace WallstopStudios.DataVisualizer.Editor
 
             if (changed)
             {
+                if (currentManagedList.Count == 0)
+                {
+                    RemoveNamespaceCollapseState(dataVisualizer, namespaceKey);
+                }
+
                 PersistManagedTypesList(dataVisualizer, currentManagedList);
                 DataVisualizer.SignalRefresh();
             }
@@ -802,6 +786,11 @@ namespace WallstopStudios.DataVisualizer.Editor
             {
                 dataVisualizer.SetLastSelectedObjectGuidForType(typeName, null);
                 RemoveTypeOrderEntry(dataVisualizer, namespaceKey, typeName);
+                if (currentManagedList.Count == 0)
+                {
+                    RemoveNamespaceCollapseState(dataVisualizer, namespaceKey);
+                }
+
                 PersistManagedTypesList(dataVisualizer, currentManagedList);
                 DataVisualizer.SignalRefresh();
             }
@@ -866,6 +855,22 @@ namespace WallstopStudios.DataVisualizer.Editor
                     );
                     return orderEntry != null && orderEntry.typeNames.Remove(typeName);
                 }
+            );
+        }
+
+        private static void RemoveNamespaceCollapseState(
+            DataVisualizer dataVisualizer,
+            string namespaceKey
+        )
+        {
+            if (string.IsNullOrWhiteSpace(namespaceKey))
+            {
+                return;
+            }
+
+            dataVisualizer.PersistSettings(
+                settings => settings.RemoveNamespaceCollapseState(namespaceKey),
+                userState => userState.RemoveNamespaceCollapseState(namespaceKey)
             );
         }
 

--- a/Editor/DataVisualizer/NamespaceController.cs
+++ b/Editor/DataVisualizer/NamespaceController.cs
@@ -557,7 +557,7 @@ namespace WallstopStudios.DataVisualizer.Editor
                     return;
                 }
 
-                SetLastSelectedTypeName(dataVisualizer, typeFullName);
+                SetLastSelectedTypeFullName(dataVisualizer, typeFullName);
             }
             catch (Exception e)
             {
@@ -565,7 +565,7 @@ namespace WallstopStudios.DataVisualizer.Editor
             }
         }
 
-        private static void SetLastSelectedTypeName(
+        private static void SetLastSelectedTypeFullName(
             DataVisualizer dataVisualizer,
             string typeFullName
         )

--- a/Editor/DataVisualizer/Styles/DataVisualizerStyles.uss
+++ b/Editor/DataVisualizer/Styles/DataVisualizerStyles.uss
@@ -645,12 +645,17 @@
 
 .type-search-field {
     flex-grow: 0;
+    flex-shrink: 0;
+    height: 24px;
+    min-height: 24px;
     margin: 5px;
     border-radius: 4px;
 }
 
 .type-search-field > #unity-text-input {
     border-top-right-radius: 0;
+    height: 100%;
+    min-height: 0;
 }
 
 .empty-object-list-label {
@@ -666,8 +671,14 @@
     padding: 2px 5px;
     background-color: transparent;
     border-radius: 5px;
-    flex-grow: 1;
-    flex-shrink: 1;
+    flex-grow: 0;
+    flex-shrink: 0;
+    height: 24px;
+    min-height: 24px;
+    min-width: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .type-selection-list-item:hover {
@@ -685,6 +696,13 @@
     margin-bottom: 2px;
     padding: 2px 6px;
     -unity-font-style: bold;
+    flex-shrink: 1;
+    height: 28px;
+    min-height: 28px;
+    min-width: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
     border-width: 2px;
     border-radius: 5px;
     border-color: transparent;
@@ -767,6 +785,9 @@
 }
 
 .type-add-search-field {
+    flex-shrink: 0;
+    height: 24px;
+    min-height: 24px;
     margin: 4px;
     margin-bottom: 2px;
     border-radius: 8px;
@@ -774,6 +795,8 @@
 
 .type-add-search-field > #unity-text-input {
     border-color: transparent;
+    height: 100%;
+    min-height: 0;
 }
 
 .type-add-search-field > #unity-text-input > .unity-text-element {

--- a/Editor/DataVisualizer/Unity/DataVisualizerAssetPostProcessor.cs
+++ b/Editor/DataVisualizer/Unity/DataVisualizerAssetPostProcessor.cs
@@ -17,7 +17,12 @@ namespace WallstopStudios.DataVisualizer.Editor.Unity
             string[] movedFromAssetPaths
         )
         {
-            if (deletedAssets.Length <= 0)
+            if (
+                importedAssets.Length <= 0
+                && deletedAssets.Length <= 0
+                && movedAssets.Length <= 0
+                && movedFromAssetPaths.Length <= 0
+            )
             {
                 return;
             }
@@ -31,16 +36,25 @@ namespace WallstopStudios.DataVisualizer.Editor.Unity
             HashSet<Type> relevantTypes = window
                 ._scriptableObjectTypes.SelectMany(x => x.Value)
                 .ToHashSet();
-            if (deletedAssets.Any(asset => IsRelevantAsset(relevantTypes, asset)))
+            if (
+                deletedAssets.Any(IsDeletedAssetPathRelevant)
+                || importedAssets.Any(asset => IsRelevantAsset(relevantTypes, asset))
+                || movedAssets.Any(asset => IsRelevantAsset(relevantTypes, asset))
+                || movedFromAssetPaths.Any(IsDeletedAssetPathRelevant)
+            )
             {
                 EditorApplication.delayCall += DataVisualizer.SignalRefresh;
             }
         }
 
+        public static bool IsDeletedAssetPathRelevant(string path)
+        {
+            return path?.EndsWith(".asset", StringComparison.OrdinalIgnoreCase) == true;
+        }
+
         internal static bool IsRelevantAsset(HashSet<Type> relevantTypes, string path)
         {
-            bool isAsset = path.EndsWith(".asset", StringComparison.OrdinalIgnoreCase);
-            if (!isAsset)
+            if (!IsDeletedAssetPathRelevant(path))
             {
                 return false;
             }

--- a/Tests/Editor/NamespaceOrderingTests.cs
+++ b/Tests/Editor/NamespaceOrderingTests.cs
@@ -1,0 +1,119 @@
+namespace WallstopStudios.DataVisualizer.Tests.Editor
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using NUnit.Framework;
+    using UnityEngine;
+    using WallstopStudios.DataVisualizer.Editor.Data;
+    using CollisionA = WallstopStudios.DataVisualizer.Tests.Editor.TypeIdentityCollision.First.Data;
+    using CollisionB = WallstopStudios.DataVisualizer.Tests.Editor.TypeIdentityCollision.Second.Data;
+
+    public sealed class NamespaceOrderingTests
+    {
+        [Test]
+        public void Should_OrderTypesByFullName_When_ShortTypeNamesCollide()
+        {
+            Type firstType = typeof(CollisionA.OrderCollisionData);
+            Type secondType = typeof(CollisionB.OrderCollisionData);
+            List<Type> types = new() { firstType, secondType };
+            List<string> persistedFullNameOrder = new() { secondType.FullName, firstType.FullName };
+
+            types.Sort(
+                (lhs, rhs) =>
+                    NamespaceTypeOrder.CompareTypesByFullNameOrder(lhs, rhs, persistedFullNameOrder)
+            );
+
+            CollectionAssert.AreEqual(
+                persistedFullNameOrder,
+                types.Select(type => type.FullName).ToList()
+            );
+            Assert.AreEqual(firstType.Name, secondType.Name);
+        }
+
+        [Test]
+        public void Should_FallBackToFullNameOrdering_When_NoCustomOrderExists()
+        {
+            Type firstType = typeof(CollisionA.OrderCollisionData);
+            Type secondType = typeof(CollisionB.OrderCollisionData);
+            List<Type> types = new() { secondType, firstType };
+
+            types.Sort(
+                (lhs, rhs) =>
+                    NamespaceTypeOrder.CompareTypesByFullNameOrder(lhs, rhs, Array.Empty<string>())
+            );
+
+            CollectionAssert.AreEqual(
+                new[] { firstType.FullName, secondType.FullName }.OrderBy(
+                    typeFullName => typeFullName,
+                    StringComparer.Ordinal
+                ),
+                types.Select(type => type.FullName).ToList()
+            );
+        }
+
+        [Test]
+        public void Should_OrderTypesByFullName_When_SeedingPersistedOrder()
+        {
+            Type firstType = typeof(CollisionA.OrderCollisionData);
+            Type secondType = typeof(CollisionB.OrderCollisionData);
+            List<Type> types = new() { secondType, firstType };
+
+            types.Sort(NamespaceTypeOrder.CompareTypesByFullName);
+
+            CollectionAssert.AreEqual(
+                new[] { firstType.FullName, secondType.FullName }.OrderBy(
+                    typeFullName => typeFullName,
+                    StringComparer.Ordinal
+                ),
+                types.Select(type => type.FullName).ToList()
+            );
+        }
+
+        [Test]
+        public void Should_UseFullNameTieBreaker_When_DisplayNamesCollide()
+        {
+            Type firstType = typeof(CollisionA.OrderCollisionData);
+            Type secondType = typeof(CollisionB.OrderCollisionData);
+            List<Type> types = new() { secondType, firstType };
+
+            types.Sort(NamespaceTypeOrder.CompareTypesByNameThenFullName);
+
+            CollectionAssert.AreEqual(
+                new[] { firstType.FullName, secondType.FullName }.OrderBy(
+                    typeFullName => typeFullName,
+                    StringComparer.Ordinal
+                ),
+                types.Select(type => type.FullName).ToList()
+            );
+            Assert.AreEqual(firstType.Name, secondType.Name);
+        }
+
+        [Test]
+        public void Should_FindTypeByFullName_When_ShortTypeNamesCollide()
+        {
+            Type firstType = typeof(CollisionA.OrderCollisionData);
+            Type secondType = typeof(CollisionB.OrderCollisionData);
+            List<Type> types = new() { firstType, secondType };
+
+            Type resolvedType = NamespaceTypeOrder.FindTypeByFullName(types, secondType.FullName);
+
+            Assert.AreSame(secondType, resolvedType);
+            Assert.AreEqual(firstType.Name, secondType.Name);
+        }
+    }
+}
+
+namespace WallstopStudios.DataVisualizer.Tests.Editor.TypeIdentityCollision.First.Data
+{
+    using UnityEngine;
+
+    public sealed class OrderCollisionData : ScriptableObject { }
+}
+
+namespace WallstopStudios.DataVisualizer.Tests.Editor.TypeIdentityCollision.Second.Data
+{
+    using UnityEngine;
+
+    public sealed class OrderCollisionData : ScriptableObject { }
+}

--- a/Tests/Editor/NamespaceOrderingTests.cs
+++ b/Tests/Editor/NamespaceOrderingTests.cs
@@ -5,6 +5,7 @@ namespace WallstopStudios.DataVisualizer.Tests.Editor
     using System.Linq;
     using NUnit.Framework;
     using UnityEngine;
+    using WallstopStudios.DataVisualizer.Editor;
     using WallstopStudios.DataVisualizer.Editor.Data;
     using CollisionA = WallstopStudios.DataVisualizer.Tests.Editor.TypeIdentityCollision.First.Data;
     using CollisionB = WallstopStudios.DataVisualizer.Tests.Editor.TypeIdentityCollision.Second.Data;
@@ -100,6 +101,25 @@ namespace WallstopStudios.DataVisualizer.Tests.Editor
 
             Assert.AreSame(secondType, resolvedType);
             Assert.AreEqual(firstType.Name, secondType.Name);
+        }
+
+        [Test]
+        public void Should_PreserveOtherNamespaces_When_RemovingManagedTypeNames()
+        {
+            string[] managedTypeNames =
+            {
+                "Gameplay.EnemyData",
+                "UI.MenuData",
+                "Gameplay.SpawnData",
+            };
+            string[] removedTypeNames = { "Gameplay.EnemyData", "Gameplay.SpawnData" };
+
+            List<string> result = NamespaceController.RemoveManagedTypeNames(
+                managedTypeNames,
+                removedTypeNames
+            );
+
+            CollectionAssert.AreEqual(new[] { "UI.MenuData" }, result);
         }
     }
 }

--- a/Tests/Editor/NamespaceOrderingTests.cs.meta
+++ b/Tests/Editor/NamespaceOrderingTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6046e5e9b9084fce809605fd0b94290d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: ""
+  assetBundleName: ""
+  assetBundleVariant: ""

--- a/Tests/Editor/SelectionPersistenceTests.cs
+++ b/Tests/Editor/SelectionPersistenceTests.cs
@@ -183,9 +183,10 @@ namespace WallstopStudios.DataVisualizer.Tests.Editor
                 AssetDatabase.SaveAssets();
 
                 string assetGuid = AssetDatabase.AssetPathToGUID(assetPath);
+                string upperGuid = assetGuid.ToUpperInvariant();
                 string[] includedGuids = DataVisualizer.IncludeResolvedSavedObjectGuid(
                     typeof(SelectionPersistenceGuidData),
-                    assetGuid,
+                    upperGuid,
                     Array.Empty<string>(),
                     out string normalizedSavedObjectGuid
                 );

--- a/Tests/Editor/SelectionPersistenceTests.cs
+++ b/Tests/Editor/SelectionPersistenceTests.cs
@@ -237,6 +237,78 @@ namespace WallstopStudios.DataVisualizer.Tests.Editor
         }
 
         [Test]
+        public void Should_PreserveSavedGuid_When_FindAssetsAlreadyReturnedIt()
+        {
+            string folderName =
+                "DataVisualizerSelectionPersistenceTests_" + Guid.NewGuid().ToString("N");
+            string folderPath = "Assets/" + folderName;
+            string assetPath = folderPath + "/Selection.asset";
+
+            AssetDatabase.CreateFolder("Assets", folderName);
+            SelectionPersistenceGuidData asset =
+                ScriptableObject.CreateInstance<SelectionPersistenceGuidData>();
+
+            try
+            {
+                AssetDatabase.CreateAsset(asset, assetPath);
+                AssetDatabase.SaveAssets();
+
+                string savedGuid = AssetDatabase.AssetPathToGUID(assetPath);
+
+                string[] includedGuids = DataVisualizer.IncludeResolvedSavedObjectGuid(
+                    typeof(SelectionPersistenceGuidData),
+                    savedGuid,
+                    new[] { savedGuid },
+                    out string normalizedSavedObjectGuid
+                );
+
+                CollectionAssert.AreEqual(new[] { savedGuid }, includedGuids);
+                Assert.AreEqual(savedGuid, normalizedSavedObjectGuid);
+            }
+            finally
+            {
+                AssetDatabase.DeleteAsset(folderPath);
+                AssetDatabase.Refresh();
+            }
+        }
+
+        [Test]
+        public void Should_ClearSavedGuid_When_FindAssetsReturnedWrongExactType()
+        {
+            string folderName =
+                "DataVisualizerSelectionPersistenceTests_" + Guid.NewGuid().ToString("N");
+            string folderPath = "Assets/" + folderName;
+            string assetPath = folderPath + "/Other.asset";
+
+            AssetDatabase.CreateFolder("Assets", folderName);
+            OtherSelectionPersistenceGuidData asset =
+                ScriptableObject.CreateInstance<OtherSelectionPersistenceGuidData>();
+
+            try
+            {
+                AssetDatabase.CreateAsset(asset, assetPath);
+                AssetDatabase.SaveAssets();
+
+                string savedGuid = AssetDatabase.AssetPathToGUID(assetPath);
+
+                string[] includedGuids = DataVisualizer.IncludeResolvedSavedObjectGuid(
+                    typeof(SelectionPersistenceGuidData),
+                    savedGuid,
+                    new[] { savedGuid },
+                    out string normalizedSavedObjectGuid
+                );
+
+                CollectionAssert.AreEqual(new[] { savedGuid }, includedGuids);
+                Assert.IsNull(normalizedSavedObjectGuid);
+            }
+            finally
+            {
+                AssetDatabase.DeleteAsset(folderPath);
+                AssetDatabase.Refresh();
+            }
+        }
+
+        [Test]
         public void Should_TreatDeletedAssetPathAsRelevant_When_PathIsAsset()
         {
             Assert.IsTrue(

--- a/Tests/Editor/SelectionPersistenceTests.cs
+++ b/Tests/Editor/SelectionPersistenceTests.cs
@@ -1,0 +1,254 @@
+namespace WallstopStudios.DataVisualizer.Tests.Editor
+{
+    using System;
+    using System.Collections.Generic;
+    using NUnit.Framework;
+    using UnityEditor;
+    using UnityEngine;
+    using UnityEngine.UIElements;
+    using WallstopStudios.DataVisualizer.Editor;
+    using WallstopStudios.DataVisualizer.Editor.Data;
+    using WallstopStudios.DataVisualizer.Editor.Styles;
+    using WallstopStudios.DataVisualizer.Editor.Unity;
+    using CollisionA = WallstopStudios.DataVisualizer.Tests.Editor.TypeIdentityCollision.First.Data;
+    using CollisionB = WallstopStudios.DataVisualizer.Tests.Editor.TypeIdentityCollision.Second.Data;
+
+    public sealed class SelectionPersistenceTests
+    {
+        [Test]
+        public void Should_FindNamespaceGroup_When_TypeElementIsNestedInNamespace()
+        {
+            VisualElement namespaceList = new() { name = "namespace-list" };
+            VisualElement namespaceGroup = new() { name = "namespace-group" };
+            namespaceGroup.AddToClassList(StyleConstants.NamespaceItemClass);
+            VisualElement typeContainer = new() { name = "types-container" };
+            VisualElement typeItem = new() { name = "type-item" };
+            typeItem.AddToClassList(StyleConstants.TypeItemClass);
+
+            namespaceList.Add(namespaceGroup);
+            namespaceGroup.Add(typeContainer);
+            typeContainer.Add(typeItem);
+
+            Assert.AreSame(
+                namespaceGroup,
+                DataVisualizer.FindAncestorNamespaceGroup(typeItem, namespaceList)
+            );
+        }
+
+        [Test]
+        public void Should_NotReturnObjectRow_When_FindingNamespaceGroup()
+        {
+            VisualElement namespaceList = new() { name = "namespace-list" };
+            VisualElement namespaceGroup = new() { name = "namespace-group" };
+            namespaceGroup.AddToClassList(StyleConstants.NamespaceItemClass);
+            VisualElement objectRow = new() { name = "object-row" };
+            objectRow.AddToClassList("object-item");
+            VisualElement typeItem = new() { name = "type-item" };
+            typeItem.AddToClassList(StyleConstants.TypeItemClass);
+
+            namespaceList.Add(namespaceGroup);
+            namespaceGroup.Add(objectRow);
+            objectRow.Add(typeItem);
+
+            Assert.AreSame(
+                namespaceGroup,
+                DataVisualizer.FindAncestorNamespaceGroup(typeItem, namespaceList)
+            );
+        }
+
+        [Test]
+        public void Should_ReturnFirstNamespaceKey_When_SavedNamespaceIsUnavailable()
+        {
+            Dictionary<string, int> namespaceOrder = new()
+            {
+                ["Gamma"] = 2,
+                ["Alpha"] = 0,
+                ["Beta"] = 1,
+            };
+
+            Assert.AreEqual("Alpha", DataVisualizer.FindFirstNamespaceKeyByOrder(namespaceOrder));
+        }
+
+        [Test]
+        public void Should_UseOrdinalNamespaceKeyTieBreaker_When_NamespaceOrderCollides()
+        {
+            Dictionary<string, int> namespaceOrder = new() { ["Beta"] = 0, ["Alpha"] = 0 };
+
+            Assert.AreEqual("Alpha", DataVisualizer.FindFirstNamespaceKeyByOrder(namespaceOrder));
+        }
+
+        [Test]
+        public void Should_ResolveSavedTypeByFullName_When_SavedNamespaceIsStale()
+        {
+            Type firstType = typeof(CollisionA.OrderCollisionData);
+            Type secondType = typeof(CollisionB.OrderCollisionData);
+            Dictionary<string, List<Type>> typesByNamespace = new()
+            {
+                ["First"] = new List<Type> { firstType },
+                ["Second"] = new List<Type> { secondType },
+            };
+            Dictionary<string, int> namespaceOrder = new() { ["First"] = 0, ["Second"] = 1 };
+
+            Type resolvedType = DataVisualizer.ResolveSelectedTypeByFullName(
+                typesByNamespace,
+                namespaceOrder,
+                "Missing",
+                secondType.FullName
+            );
+
+            Assert.AreSame(secondType, resolvedType);
+            Assert.AreEqual(firstType.Name, secondType.Name);
+        }
+
+        [Test]
+        public void Should_RemoveStoredObjectSelection_When_GuidIsCleared()
+        {
+            DataVisualizerUserState userState = new();
+            const string typeFullName = "Example.Type";
+            const string objectGuid = "0123456789abcdef0123456789abcdef";
+
+            Assert.IsTrue(userState.SetLastObjectForType(typeFullName, objectGuid));
+            Assert.AreEqual(objectGuid, userState.GetLastObjectForType(typeFullName));
+
+            Assert.IsFalse(
+                userState.SetLastObjectForType(typeFullName, objectGuid),
+                "duplicate saved object selection should be unchanged"
+            );
+
+            Assert.IsTrue(userState.SetLastObjectForType(typeFullName, null));
+            Assert.IsNull(userState.GetLastObjectForType(typeFullName));
+            Assert.IsFalse(
+                userState.SetLastObjectForType(typeFullName, null),
+                "clearing an absent saved object selection should be unchanged"
+            );
+        }
+
+        [Test]
+        public void Should_ResolveSavedObjectGuidOnlyForExactType()
+        {
+            string folderName =
+                "DataVisualizerSelectionPersistenceTests_" + Guid.NewGuid().ToString("N");
+            string folderPath = "Assets/" + folderName;
+            string assetPath = folderPath + "/Selection.asset";
+
+            AssetDatabase.CreateFolder("Assets", folderName);
+            SelectionPersistenceGuidData asset =
+                ScriptableObject.CreateInstance<SelectionPersistenceGuidData>();
+
+            try
+            {
+                AssetDatabase.CreateAsset(asset, assetPath);
+                AssetDatabase.SaveAssets();
+
+                string assetGuid = AssetDatabase.AssetPathToGUID(assetPath);
+
+                Assert.IsTrue(
+                    DataVisualizer.TryResolveAssetGuidForType(
+                        assetGuid,
+                        typeof(SelectionPersistenceGuidData),
+                        out string resolvedPath
+                    )
+                );
+                Assert.AreEqual(assetPath, resolvedPath);
+                Assert.IsFalse(
+                    DataVisualizer.TryResolveAssetGuidForType(
+                        assetGuid,
+                        typeof(OtherSelectionPersistenceGuidData),
+                        out _
+                    )
+                );
+            }
+            finally
+            {
+                AssetDatabase.DeleteAsset(folderPath);
+                AssetDatabase.Refresh();
+            }
+        }
+
+        [Test]
+        public void Should_IncludeDirectlyResolvedSavedGuid_When_FindAssetsMissesIt()
+        {
+            string folderName =
+                "DataVisualizerSelectionPersistenceTests_" + Guid.NewGuid().ToString("N");
+            string folderPath = "Assets/" + folderName;
+            string assetPath = folderPath + "/Selection.asset";
+
+            AssetDatabase.CreateFolder("Assets", folderName);
+            SelectionPersistenceGuidData asset =
+                ScriptableObject.CreateInstance<SelectionPersistenceGuidData>();
+
+            try
+            {
+                AssetDatabase.CreateAsset(asset, assetPath);
+                AssetDatabase.SaveAssets();
+
+                string assetGuid = AssetDatabase.AssetPathToGUID(assetPath);
+                string[] includedGuids = DataVisualizer.IncludeResolvedSavedObjectGuid(
+                    typeof(SelectionPersistenceGuidData),
+                    assetGuid,
+                    Array.Empty<string>(),
+                    out string normalizedSavedObjectGuid
+                );
+
+                CollectionAssert.AreEqual(new[] { assetGuid }, includedGuids);
+                Assert.AreEqual(assetGuid, normalizedSavedObjectGuid);
+            }
+            finally
+            {
+                AssetDatabase.DeleteAsset(folderPath);
+                AssetDatabase.Refresh();
+            }
+        }
+
+        [Test]
+        public void Should_NormalizeSavedGuid_When_FindAssetsReturnsDifferentCasing()
+        {
+            string folderName =
+                "DataVisualizerSelectionPersistenceTests_" + Guid.NewGuid().ToString("N");
+            string folderPath = "Assets/" + folderName;
+            string assetPath = folderPath + "/Selection.asset";
+
+            AssetDatabase.CreateFolder("Assets", folderName);
+            SelectionPersistenceGuidData asset =
+                ScriptableObject.CreateInstance<SelectionPersistenceGuidData>();
+
+            try
+            {
+                AssetDatabase.CreateAsset(asset, assetPath);
+                AssetDatabase.SaveAssets();
+
+                string assetGuid = AssetDatabase.AssetPathToGUID(assetPath);
+                string upperGuid = assetGuid.ToUpperInvariant();
+                string[] includedGuids = DataVisualizer.IncludeResolvedSavedObjectGuid(
+                    typeof(SelectionPersistenceGuidData),
+                    upperGuid,
+                    new[] { assetGuid },
+                    out string normalizedSavedObjectGuid
+                );
+
+                CollectionAssert.AreEqual(new[] { assetGuid }, includedGuids);
+                Assert.AreEqual(assetGuid, normalizedSavedObjectGuid);
+            }
+            finally
+            {
+                AssetDatabase.DeleteAsset(folderPath);
+                AssetDatabase.Refresh();
+            }
+        }
+
+        [Test]
+        public void Should_TreatDeletedAssetPathAsRelevant_When_PathIsAsset()
+        {
+            Assert.IsTrue(
+                DataVisualizerAssetProcessor.IsDeletedAssetPathRelevant("Assets/Deleted.asset")
+            );
+            Assert.IsFalse(
+                DataVisualizerAssetProcessor.IsDeletedAssetPathRelevant("Assets/Deleted.prefab")
+            );
+        }
+    }
+
+    public sealed class SelectionPersistenceGuidData : ScriptableObject { }
+
+    public sealed class OtherSelectionPersistenceGuidData : ScriptableObject { }
+}

--- a/Tests/Editor/SelectionPersistenceTests.cs.meta
+++ b/Tests/Editor/SelectionPersistenceTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5a2e4a112b5b4ab0b6d215d71503c816
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: ""
+  assetBundleName: ""
+  assetBundleVariant: ""

--- a/Tests/Editor/SettingsPersistenceTests.cs
+++ b/Tests/Editor/SettingsPersistenceTests.cs
@@ -144,6 +144,14 @@ namespace WallstopStudios.DataVisualizer.Tests.Editor
             "{\"lastSelectedTypeName\":\"Example.Namespace.LegacyData\",\"lastSelectedTypeFullName\":\"Example.Namespace.CurrentData\"}",
             "Example.Namespace.CurrentData"
         )]
+        [TestCase(
+            "{\"lastSelectedTypeName\":\"Example.Namespace.LegacyData\",\"lastSelectedTypeFullName\":\"\"}",
+            "Example.Namespace.LegacyData"
+        )]
+        [TestCase(
+            "{\"lastSelectedNamespaceKey\":\"\\\"lastSelectedTypeFullName\\\"\",\"lastSelectedTypeName\":\"Example.Namespace.LegacyData\"}",
+            "Example.Namespace.LegacyData"
+        )]
         public void Should_MigrateLegacySelectedTypeName_When_LoadingUserStateJson(
             string json,
             string expectedTypeFullName

--- a/Tests/Editor/SettingsPersistenceTests.cs
+++ b/Tests/Editor/SettingsPersistenceTests.cs
@@ -136,6 +136,24 @@ namespace WallstopStudios.DataVisualizer.Tests.Editor
             );
         }
 
+        [TestCase(
+            "{\"lastSelectedTypeName\":\"Example.Namespace.LegacyData\"}",
+            "Example.Namespace.LegacyData"
+        )]
+        [TestCase(
+            "{\"lastSelectedTypeName\":\"Example.Namespace.LegacyData\",\"lastSelectedTypeFullName\":\"Example.Namespace.CurrentData\"}",
+            "Example.Namespace.CurrentData"
+        )]
+        public void Should_MigrateLegacySelectedTypeName_When_LoadingUserStateJson(
+            string json,
+            string expectedTypeFullName
+        )
+        {
+            DataVisualizerUserState userState = DataVisualizerUserState.FromJson(json);
+
+            Assert.AreEqual(expectedTypeFullName, userState.lastSelectedTypeFullName);
+        }
+
         private static void AssertCollapseStateDirtySemantics(
             Func<string, bool, bool> setCollapsed,
             Func<string, bool> removeCollapsed

--- a/Tests/Editor/SettingsPersistenceTests.cs
+++ b/Tests/Editor/SettingsPersistenceTests.cs
@@ -1,0 +1,160 @@
+namespace WallstopStudios.DataVisualizer.Tests.Editor
+{
+    using System;
+    using NUnit.Framework;
+    using UnityEditor;
+    using UnityEngine;
+    using WallstopStudios.DataVisualizer.Editor;
+    using WallstopStudios.DataVisualizer.Editor.Data;
+
+    public sealed class SettingsPersistenceTests
+    {
+        [Test]
+        public void Should_MarkSettingsDirty_When_SelectActiveObjectChanges()
+        {
+            DataVisualizerSettings settings =
+                ScriptableObject.CreateInstance<DataVisualizerSettings>();
+            try
+            {
+                settings.selectActiveObject = false;
+                EditorUtility.ClearDirty(settings);
+
+                Assert.IsFalse(EditorUtility.IsDirty(settings));
+                Assert.IsTrue(settings.SetSelectActiveObject(true));
+                Assert.IsTrue(settings.selectActiveObject);
+                Assert.IsTrue(EditorUtility.IsDirty(settings));
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(settings);
+            }
+        }
+
+        [Test]
+        public void Should_NotMarkSettingsDirty_When_SelectActiveObjectIsUnchanged()
+        {
+            DataVisualizerSettings settings =
+                ScriptableObject.CreateInstance<DataVisualizerSettings>();
+            try
+            {
+                settings.selectActiveObject = true;
+                EditorUtility.ClearDirty(settings);
+
+                Assert.IsFalse(settings.SetSelectActiveObject(true));
+                Assert.IsTrue(settings.selectActiveObject);
+                Assert.IsFalse(EditorUtility.IsDirty(settings));
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(settings);
+            }
+        }
+
+        [Test]
+        public void Should_MarkSettingsDirty_When_SelectActiveObjectPreferenceChangesThroughWindowHelper()
+        {
+            DataVisualizerSettings settings =
+                ScriptableObject.CreateInstance<DataVisualizerSettings>();
+            try
+            {
+                settings.selectActiveObject = false;
+                EditorUtility.ClearDirty(settings);
+
+                Assert.IsTrue(DataVisualizer.ApplySelectActiveObjectPreference(settings, true));
+                Assert.IsTrue(settings.selectActiveObject);
+                Assert.IsTrue(EditorUtility.IsDirty(settings));
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(settings);
+            }
+        }
+
+        [Test]
+        public void Should_ReportDirtyOnlyForActualCollapseStateChanges_When_UsingSettingsStore()
+        {
+            DataVisualizerSettings settings =
+                ScriptableObject.CreateInstance<DataVisualizerSettings>();
+            try
+            {
+                const string namespaceKey = "Gameplay";
+
+                EditorUtility.ClearDirty(settings);
+                Assert.IsTrue(
+                    settings.SetNamespaceCollapsed(namespaceKey, false),
+                    "first write stores expanded state"
+                );
+                Assert.IsTrue(EditorUtility.IsDirty(settings));
+
+                EditorUtility.ClearDirty(settings);
+                Assert.IsFalse(
+                    settings.SetNamespaceCollapsed(namespaceKey, false),
+                    "duplicate expanded write is unchanged"
+                );
+                Assert.IsFalse(EditorUtility.IsDirty(settings));
+
+                Assert.IsTrue(
+                    settings.SetNamespaceCollapsed(namespaceKey, true),
+                    "changed collapse state is dirty"
+                );
+                Assert.IsTrue(EditorUtility.IsDirty(settings));
+
+                EditorUtility.ClearDirty(settings);
+                Assert.IsFalse(
+                    settings.SetNamespaceCollapsed(namespaceKey, true),
+                    "duplicate collapsed write is unchanged"
+                );
+                Assert.IsFalse(EditorUtility.IsDirty(settings));
+
+                Assert.IsTrue(
+                    settings.RemoveNamespaceCollapseState(namespaceKey),
+                    "removing stored state is dirty"
+                );
+                Assert.IsTrue(EditorUtility.IsDirty(settings));
+
+                EditorUtility.ClearDirty(settings);
+                Assert.IsFalse(
+                    settings.RemoveNamespaceCollapseState(namespaceKey),
+                    "removing absent state is unchanged"
+                );
+                Assert.IsFalse(EditorUtility.IsDirty(settings));
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(settings);
+            }
+        }
+
+        [Test]
+        public void Should_ReportDirtyOnlyForActualCollapseStateChanges_When_UsingUserStateStore()
+        {
+            DataVisualizerUserState userState = new();
+
+            AssertCollapseStateDirtySemantics(
+                userState.SetNamespaceCollapsed,
+                userState.RemoveNamespaceCollapseState
+            );
+        }
+
+        private static void AssertCollapseStateDirtySemantics(
+            Func<string, bool, bool> setCollapsed,
+            Func<string, bool> removeCollapsed
+        )
+        {
+            const string namespaceKey = "Gameplay";
+
+            Assert.IsTrue(setCollapsed(namespaceKey, false), "first write stores expanded state");
+            Assert.IsFalse(
+                setCollapsed(namespaceKey, false),
+                "duplicate expanded write is unchanged"
+            );
+            Assert.IsTrue(setCollapsed(namespaceKey, true), "changed collapse state is dirty");
+            Assert.IsFalse(
+                setCollapsed(namespaceKey, true),
+                "duplicate collapsed write is unchanged"
+            );
+            Assert.IsTrue(removeCollapsed(namespaceKey), "removing stored state is dirty");
+            Assert.IsFalse(removeCollapsed(namespaceKey), "removing absent state is unchanged");
+        }
+    }
+}

--- a/Tests/Editor/SettingsPersistenceTests.cs.meta
+++ b/Tests/Editor/SettingsPersistenceTests.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 3d777a01284649a5846b13a6a0354b8f
+timeCreated: 1783445700

--- a/Tests/Editor/TypePopoverLayoutTests.cs
+++ b/Tests/Editor/TypePopoverLayoutTests.cs
@@ -1,0 +1,246 @@
+namespace WallstopStudios.DataVisualizer.Tests.Editor
+{
+    using System.Collections;
+    using System.Linq;
+    using NUnit.Framework;
+    using UnityEditor;
+    using UnityEngine;
+    using UnityEngine.TestTools;
+    using UnityEngine.UIElements;
+    using WallstopStudios.DataVisualizer.Editor.Styles;
+
+    public sealed class TypePopoverLayoutTests
+    {
+        private const string DataVisualizerStyleSheetPath =
+            "Packages/com.wallstop-studios.data-visualizer/Editor/DataVisualizer/Styles/DataVisualizerStyles.uss";
+        private const string PlaceholderClass = "unity-text-field__placeholder";
+        private const float LayoutTolerance = 0.01f;
+
+        private static readonly string[] SearchFieldClassNames =
+        {
+            "type-add-search-field",
+            "type-search-field",
+        };
+
+        [UnityTest]
+        public IEnumerator Should_KeepSearchFieldHeight_When_PlaceholderChangesToTypedText()
+        {
+            StyleSheet styleSheet = LoadStyleSheet();
+            Assert.NotNull(styleSheet);
+            LayoutTestWindow window = CreateWindow(styleSheet, 360, 160);
+            try
+            {
+                TextField[] fields = SearchFieldClassNames
+                    .Select(className =>
+                    {
+                        TextField field = new() { name = className };
+                        field.AddToClassList(className);
+                        window.rootVisualElement.Add(field);
+                        return field;
+                    })
+                    .ToArray();
+
+                yield return WaitForResolvedHeights(fields);
+
+                foreach (TextField field in fields)
+                {
+                    field.SetValueWithoutNotify("Search...");
+                    field.AddToClassList(PlaceholderClass);
+                }
+
+                yield return WaitForResolvedHeights(fields);
+
+                foreach (TextField field in fields)
+                {
+                    float placeholderHeight = field.resolvedStyle.height;
+                    field.RemoveFromClassList(PlaceholderClass);
+                    field.SetValueWithoutNotify("base");
+
+                    yield return WaitForResolvedHeights(field);
+
+                    Assert.That(
+                        field.resolvedStyle.height,
+                        Is.EqualTo(placeholderHeight).Within(LayoutTolerance),
+                        $"{field.name} height changed when placeholder text was replaced."
+                    );
+                }
+            }
+            finally
+            {
+                window.Close();
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator Should_KeepTypeRowHeight_When_FilterChangesVisibleRows()
+        {
+            StyleSheet styleSheet = LoadStyleSheet();
+            Assert.NotNull(styleSheet);
+            LayoutTestWindow window = CreateWindow(styleSheet, 360, 180);
+            try
+            {
+                VisualElement container = new()
+                {
+                    name = "type-add-list-content",
+                    style = { height = 120 },
+                };
+                container.AddToClassList("type-add-list-container");
+                window.rootVisualElement.Add(container);
+
+                VisualElement header = new();
+                header.AddToClassList("popover-namespace-header");
+                header.style.width = 180;
+                Label indicator = new(StyleConstants.ArrowExpanded);
+                indicator.AddToClassList("popover-namespace-indicator");
+                Label namespaceLabel = new(
+                    "WallstopStudios.DataVisualizer.Tests.Editor.Generated.Namespace"
+                );
+                namespaceLabel.AddToClassList("type-selection-list-namespace");
+                namespaceLabel.AddToClassList("type-selection-list-namespace--not-empty");
+                header.Add(indicator);
+                header.Add(namespaceLabel);
+
+                Label firstRow = CreateTypeRow("BaseData");
+                Label secondRow = CreateTypeRow("AdvancedData");
+                container.Add(header);
+                container.Add(firstRow);
+                container.Add(secondRow);
+
+                yield return WaitForResolvedHeights(header, namespaceLabel, firstRow, secondRow);
+
+                float unfilteredHeaderHeight = header.resolvedStyle.height;
+                float unfilteredNamespaceHeight = namespaceLabel.resolvedStyle.height;
+                float unfilteredHeight = firstRow.resolvedStyle.height;
+                Assert.That(
+                    namespaceLabel.resolvedStyle.width,
+                    Is.LessThanOrEqualTo(header.resolvedStyle.width)
+                );
+
+                container.Remove(secondRow);
+                namespaceLabel.enableRichText = true;
+                namespaceLabel.text =
+                    "WallstopStudios.<color=yellow><b>DataVisualizer</b></color>.Tests.Editor.Generated.Namespace";
+                firstRow.enableRichText = true;
+                firstRow.text = "<color=yellow><b>Base</b></color>Data";
+
+                yield return WaitForResolvedHeights(header, namespaceLabel, firstRow);
+
+                Assert.That(
+                    header.resolvedStyle.height,
+                    Is.EqualTo(unfilteredHeaderHeight).Within(LayoutTolerance)
+                );
+                Assert.That(
+                    namespaceLabel.resolvedStyle.height,
+                    Is.EqualTo(unfilteredNamespaceHeight).Within(LayoutTolerance)
+                );
+                Assert.That(
+                    firstRow.resolvedStyle.height,
+                    Is.EqualTo(unfilteredHeight).Within(LayoutTolerance)
+                );
+            }
+            finally
+            {
+                window.Close();
+            }
+        }
+
+        private static Label CreateTypeRow(string text)
+        {
+            Label row = new(text);
+            row.AddToClassList("type-selection-list-item");
+            return row;
+        }
+
+        private static LayoutTestWindow CreateWindow(
+            StyleSheet styleSheet,
+            float width,
+            float height
+        )
+        {
+            LayoutTestWindow window = EditorWindow.CreateWindow<LayoutTestWindow>();
+            window.titleContent = new GUIContent(nameof(TypePopoverLayoutTests));
+            window.position = new Rect(100, 100, width, height);
+            window.rootVisualElement.styleSheets.Add(styleSheet);
+            window.rootVisualElement.style.width = width;
+            window.rootVisualElement.style.height = height;
+            window.ShowUtility();
+            return window;
+        }
+
+        private static StyleSheet LoadStyleSheet()
+        {
+            StyleSheet styleSheet = AssetDatabase.LoadAssetAtPath<StyleSheet>(
+                DataVisualizerStyleSheetPath
+            );
+            if (styleSheet != null)
+            {
+                return styleSheet;
+            }
+
+            return AssetDatabase
+                .FindAssets("DataVisualizerStyles t:StyleSheet")
+                .Select(AssetDatabase.GUIDToAssetPath)
+                .Where(path =>
+                    path.EndsWith(
+                        "/Editor/DataVisualizer/Styles/DataVisualizerStyles.uss",
+                        System.StringComparison.Ordinal
+                    )
+                )
+                .Select(AssetDatabase.LoadAssetAtPath<StyleSheet>)
+                .FirstOrDefault(sheet => sheet != null);
+        }
+
+        private static IEnumerator WaitForResolvedHeights(params VisualElement[] elements)
+        {
+            float[] previousHeights = null;
+            for (int frame = 0; frame < 30; frame++)
+            {
+                yield return null;
+
+                bool allReady = elements.All(element =>
+                    element?.panel != null && IsPositiveFinite(element.resolvedStyle.height)
+                );
+                if (!allReady)
+                {
+                    previousHeights = null;
+                    continue;
+                }
+
+                float[] currentHeights = elements
+                    .Select(element => element.resolvedStyle.height)
+                    .ToArray();
+                if (
+                    previousHeights != null
+                    && currentHeights
+                        .Zip(
+                            previousHeights,
+                            (current, previous) => Mathf.Abs(current - previous) <= LayoutTolerance
+                        )
+                        .All(stable => stable)
+                )
+                {
+                    yield break;
+                }
+
+                previousHeights = currentHeights;
+            }
+
+            string heightSummary = string.Join(
+                ", ",
+                elements.Select(element =>
+                    element == null
+                        ? "<null>"
+                        : $"{element.name}:{element.resolvedStyle.height} panel={element.panel != null}"
+                )
+            );
+            Assert.Fail($"Timed out waiting for stable positive layout heights: {heightSummary}");
+        }
+
+        private static bool IsPositiveFinite(float value)
+        {
+            return value > 0 && !float.IsNaN(value) && !float.IsInfinity(value);
+        }
+
+        private sealed class LayoutTestWindow : EditorWindow { }
+    }
+}

--- a/Tests/Editor/TypePopoverLayoutTests.cs.meta
+++ b/Tests/Editor/TypePopoverLayoutTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e757b69d83544f308b98cf82850b7ada

--- a/Tests/Editor/WallstopStudios.DataVisualizer.Tests.Editor.asmdef.meta
+++ b/Tests/Editor/WallstopStudios.DataVisualizer.Tests.Editor.asmdef.meta
@@ -2,6 +2,6 @@ fileFormatVersion: 2
 guid: ab0fcdeaf8cd4b56aac58d4f88b1aa5f
 AssemblyDefinitionImporter:
   externalObjects: {}
-  userData:
-  assetBundleName:
-  assetBundleVariant:
+  userData: ""
+  assetBundleName: ""
+  assetBundleVariant: ""


### PR DESCRIPTION
## Summary

Fixes the completed PLAN.md correctness items currently on this branch.

- marks `selectActiveObject` settings dirty through a named helper used by the settings UI callback
- centralizes namespace collapse state dirty decisions for settings and user-state storage
- clears stale namespace collapse state when removing the last managed type from a namespace
- restores namespace/type ordering by exact `Type.FullName` identity instead of short type names
- uses deterministic full-name ordering when seeding persisted type order from folder imports
- keeps add-type display ordering stable with a short-name then full-name tie-breaker
- restores selected types by full type name even when saved namespace state is stale
- restores selected objects by direct asset GUID resolution and clears stale saved GUID entries
- expands the owning namespace group for restored type selection
- treats deleted/moved-from `.asset` paths as refresh invalidations without loading deleted assets
- fixes the test asmdef `.meta` importer values so Unity parses the EditMode test assembly
- adds EditMode regression coverage for settings persistence, type identity collisions, and selection restore identity

## Validation

- `dotnet tool restore`
- `dotnet tool run csharpier -- check Editor Runtime Tests`
- `git diff --check`
- `npm pack --dry-run`
- Unity 6000.4.6f1 EditMode tests in a temporary host project at `D:\tmp\data-visualizer-unity-tests` with package dependency `file:D:/Code/Packages/Packages/com.wallstop-studios.data-visualizer`
  - Command shape omitted `-quit` so the Unity Test Framework command-line update callback could run after project load.
  - Result: `23` passed, `0` failed in `D:\tmp\data-visualizer-editmode-results.xml`.

## Risk / Rollback

Risk is limited to Unity Editor settings/user-state persistence, editor namespace/type ordering, selection restoration, and editor asset invalidation. Runtime assembly behavior is unchanged. Rollback is reverting the PR commits.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches editor settings/user-state persistence and selection restore paths where bugs could mis-order types or lose selection, but scope is editor-only with broad new tests and no runtime assembly changes.
> 
> **Overview**
> Fixes **Data Visualizer** editor state so settings and user JSON persist reliably and type/object selection uses **`Type.FullName`** instead of ambiguous short names.
> 
> **Persistence:** `selectActiveObject` and namespace collapse go through helpers that return whether anything changed, so `PersistSettings` only marks the settings asset dirty when needed. Last-object-per-type updates are idempotent (in-place update, clear on null GUID) and report change for persistence. Removing the last managed type in a namespace drops that namespace’s collapse state and fixes managed-type list updates across namespaces.
> 
> **Identity & restore:** Selected type is stored and restored as `lastSelectedTypeFullName` with `FormerlySerializedAs` and `DataVisualizerUserState.FromJson` migration from legacy `lastSelectedTypeName`. Shared ordering/resolution helpers sort and find types by full name (including custom order and popover tie-breakers). Refresh/startup use `ResolveSelectedTypeByFullName` and expand the correct namespace group via `StyleConstants.NamespaceItemClass` (not object rows). Saved object GUIDs are validated per exact type, normalized for casing, and can be included when `FindAssets` misses them; stale GUIDs clear on delete/wrong type.
> 
> **Editor refresh & UI:** Asset post-processing triggers refresh on import/move and on deleted/moved-from `.asset` paths without loading deleted files. Type-add/search USS rules fix row and field heights under filtering/rich text.
> 
> **Tests:** New EditMode coverage for persistence dirty semantics, full-name collisions, selection/GUID restore, popover layout, and test asmdef meta fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f1bc6b19d95e163201ebbc1c171f79b002a0073. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->